### PR TITLE
fix: use GitHub App token to bypass Actions PR creation restrictions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ jobs:
       new-release-version: ${{ steps.new-version.outputs.new-version }}
       
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BLAZECOMMERCE_BOT_APP_ID }}
+          private-key: ${{ secrets.BLAZECOMMERCE_BOT_PRIVATE_KEY }}
+
       - name: Validate merge commit SHA
         run: |
           if [ -z "${{ github.event.pull_request.merge_commit_sha }}" ]; then
@@ -35,7 +42,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           
 
           
@@ -46,8 +53,9 @@ jobs:
           
       - name: Configure Git
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "BlazeCommerce Automation Bot"
+          git config --global user.email "automation@blazecommerce.io"
+          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git
           
       - name: Get current version from style.css
         id: current-version
@@ -199,7 +207,7 @@ jobs:
       - name: Open PR for version bump
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const branch = '${{ steps.create-bump-branch.outputs.branch-name }}';
             const base = '${{ github.event.pull_request.base.ref }}';
@@ -293,7 +301,7 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           tag_name: v${{ steps.new-version.outputs.new-version }}
           release_name: Release v${{ steps.new-version.outputs.new-version }}
@@ -304,7 +312,7 @@ jobs:
       - name: Upload ZIP to Release
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./${{ steps.create-zip.outputs.zip-name }}
@@ -332,16 +340,24 @@ jobs:
     if: failure() && needs.release.outputs.new-release-version != ''
 
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BLAZECOMMERCE_BOT_APP_ID }}
+          private-key: ${{ secrets.BLAZECOMMERCE_BOT_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Git
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "BlazeCommerce Automation Bot"
+          git config --global user.email "automation@blazecommerce.io"
+          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git
 
       - name: Rollback tag
         run: |


### PR DESCRIPTION
## Problem

The automated release workflow is failing with the error:
```
GitHub Actions is not permitted to create or approve pull requests.
```

This occurs because the organization has restrictive workflow permissions that prevent GitHub Actions from creating PRs using the default `GITHUB_TOKEN`.

## Solution

This PR switches the workflow to use the **BlazeCommerce Automation Bot** GitHub App token instead of `GITHUB_TOKEN`, which bypasses the organization's restrictions on Actions.

## Changes Made

### 🔧 **Authentication Updates**
- Replace all `GITHUB_TOKEN` references with GitHub App token
- Add `actions/create-github-app-token@v1` step to generate app token
- Configure git remote URL with app token for authenticated operations

### 🤖 **Bot Identity**
- Set git user to "BlazeCommerce Automation Bot" 
- Use `automation@blazecommerce.io` email for commits
- Professional automation identity for all release operations

### 🔐 **Required Secrets**

Before merging, add these repository secrets:
- `BLAZECOMMERCE_BOT_APP_ID` - The GitHub App ID
- `BLAZECOMMERCE_BOT_PRIVATE_KEY` - The GitHub App private key (full PEM content)

## GitHub App Permissions Required

Ensure the BlazeCommerce Automation Bot has:
- ✅ **Contents**: Write (for branches/tags)
- ✅ **Pull Requests**: Write (for creating PRs) 
- ✅ **Issues**: Write (for releases)
- ✅ **Metadata**: Read (for repo access)

## Testing

After adding the secrets and merging:
1. The release workflow should run without PR creation errors
2. Follow-up PRs for version bumps should be created successfully
3. All GitHub API operations should work with proper authentication

## References

- Failed workflow run: https://github.com/blaze-commerce/blaze-blocksy/actions/runs/17160448410
- GitHub App installation: https://github.com/organizations/blaze-commerce/settings/installations/75808754

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author