### PR TITLE
fix: handle existing release branches to prevent push conflicts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,15 @@ jobs:
           SAFE_VERSION=$(printf '%q' "${NEW_VERSION}")
           BRANCH="release/bump-v${NEW_VERSION}"
 
+          # Check if branch already exists and delete it
+          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+            echo "Branch $BRANCH already exists, deleting it"
+            git push origin --delete "$BRANCH" || true
+          fi
+
+          # Delete local branch if it exists
+          git branch -D "$BRANCH" 2>/dev/null || true
+
           git checkout -b "$BRANCH"
           git add style.css
           git commit -m "chore(release): bump theme version to ${SAFE_VERSION}"


### PR DESCRIPTION
## Problem

The automated release workflow is failing with a branch conflict error:

```
! [rejected] release/bump-v1.1.0 -> release/bump-v1.1.0 (non-fast-forward)
error: failed to push some refs
hint: Updates were rejected because the tip of your current branch is behind
```

**Failed workflow run**: https://github.com/blaze-commerce/blaze-blocksy/actions/runs/17160759195/job/48689176898

## Root Cause

The workflow tries to create a `release/bump-vX.Y.Z` branch, but if the branch already exists from a previous workflow run, it causes a non-fast-forward conflict when trying to push.

## Solution

This PR adds proper handling for existing release branches by:

### 🔧 **Changes Made**

1. **Check for existing remote branch**: `git ls-remote --heads origin "$BRANCH"`
2. **Delete existing remote branch**: `git push origin --delete "$BRANCH"` (if exists)
3. **Delete existing local branch**: `git branch -D "$BRANCH"` (if exists)
4. **Create fresh branch**: Proceed with clean branch creation

### ✅ **Benefits**

- **Idempotent workflow**: Can run multiple times safely
- **No branch conflicts**: Handles existing release branches gracefully
- **Clean state**: Each run starts with a fresh branch
- **Error resilience**: Uses `|| true` for non-critical operations

### 🧪 **Testing**

After merging this fix:
1. The workflow should handle existing `release/bump-vX.Y.Z` branches properly
2. No more "non-fast-forward" errors when creating version bump PRs
3. Multiple workflow runs won't conflict with each other

### 📋 **Code Changes**

```bash
# Check if branch already exists and delete it
if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
  echo "Branch $BRANCH already exists, deleting it"
  git push origin --delete "$BRANCH" || true
fi

# Delete local branch if it exists
git branch -D "$BRANCH" 2>/dev/null || true
```

This ensures the workflow can create version bump branches cleanly every time, regardless of previous runs.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author