### PR TITLE
feat: disable minicart control script for standard cart flow

### DIFF
--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -34,12 +34,12 @@ add_action(
 		);
 
 		// Enqueue BlazeCommerce minicart control script
-		wp_enqueue_script(
-			'blazecommerce-minicart-control',
-			$template_uri . '/assets/js/minicart-control.js',
-			array( 'jquery', 'wc-add-to-cart' ),
-			'1.0.0',
-			true
-		);
+		// wp_enqueue_script(
+		// 	'blazecommerce-minicart-control',
+		// 	$template_uri . '/assets/js/minicart-control.js',
+		// 	array( 'jquery', 'wc-add-to-cart' ),
+		// 	'1.0.0',
+		// 	true
+		// );
 	}
 );


### PR DESCRIPTION
## 🎯 Purpose

Disables the BlazeCommerce minicart control script to maintain standard WooCommerce cart flow behavior.

## 📋 Changes Made

- **Commented out** the `blazecommerce-minicart-control` script enqueuing in `includes/scripts.php`
- Script file remains available but is not loaded
- Prevents custom cart flow modifications (redirect to homepage, auto-open minicart)
- Maintains standard WooCommerce cart page behavior

## 🔧 Technical Details

### What the script does (when enabled):
- Intercepts add-to-cart actions
- Redirects users to homepage after adding to cart
- Automatically opens minicart panel
- Bypasses standard `/cart` page entirely
- Adds edit links to checkout page order summary

### Current state (disabled):
- Standard WooCommerce cart flow is preserved
- Users go to `/cart` page after adding products
- No automatic minicart opening
- Standard checkout page behavior

## 🧪 Testing Instructions

1. **Verify script is disabled:**
   - Check browser dev tools - no `blazecommerce-minicart-control` script should load
   - No console messages from BlazeCommerce Minicart Control

2. **Test standard cart flow:**
   - Add product to cart from product page
   - Should follow standard WooCommerce behavior
   - No automatic redirect to homepage
   - No automatic minicart opening

3. **Verify cart page access:**
   - Users can access `/cart` page directly
   - Standard cart page functionality works

## 🔄 Future Considerations

- Script can be easily re-enabled by uncommenting the `wp_enqueue_script` call
- All BlazeCommerce minicart functionality remains intact in the JS file
- No breaking changes to existing functionality

## 📁 Files Changed

- `includes/scripts.php` - Commented out minicart control script enqueuing

## ✅ Checklist

- [x] Script properly commented out
- [x] No syntax errors in PHP file
- [x] Standard WooCommerce cart flow preserved
- [x] No breaking changes to existing functionality
- [x] Script can be easily re-enabled when needed

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author