### PR TITLE
feat: replace admin email with WooCommerce from email in thank-you page

### DIFF
--- a/includes/customization/thank-you-page.php
+++ b/includes/customization/thank-you-page.php
@@ -264,7 +264,10 @@ function blocksy_child_blaze_commerce_thank_you_content( $order_id ) {
 						</div>
 						<div id="resend-feedback" class="resend-feedback" style="display: none;"></div>
 						<p>
-							Need help? Contact our support team at <strong><?php echo esc_html( get_option( 'admin_email' ) ); ?></strong>
+							Need help? Contact our support team at <strong><?php
+							$support_email = get_option( 'woocommerce_email_from_address' ) ?: get_option( 'admin_email' );
+							echo esc_html( $support_email );
+							?></strong>
 						</p>
 					</div>
 					<?php


### PR DESCRIPTION
## 🎯 Context

This change improves the consistency and professionalism of the thank-you page by displaying the same email address that customers see in their WooCommerce order confirmation emails, rather than the generic WordPress admin email.

## 📝 Changes Made

### File Modified
- `includes/customization/thank-you-page.php` (lines 267-270)

### Code Changes
**Before:**
```php
Need help? Contact our support team at <strong><?php echo esc_html( get_option( 'admin_email' ) ); ?></strong>
```

**After:**
```php
Need help? Contact our support team at <strong><?php 
$support_email = get_option( 'woocommerce_email_from_address' ) ?: get_option( 'admin_email' );
echo esc_html( $support_email ); 
?></strong>
```

## 🔧 Technical Details

- **Primary Source**: `get_option( 'woocommerce_email_from_address' )` - Uses WooCommerce's configured "from" email address
- **Fallback Strategy**: Falls back to `get_option( 'admin_email' )` if WooCommerce email is not configured
- **Security**: Maintains proper escaping with `esc_html()` to prevent XSS vulnerabilities
- **Compatibility**: Works with all WooCommerce configurations and gracefully handles missing settings

## ✨ Benefits

1. **Consistency**: Displays the same email address customers see in order confirmation emails
2. **Professional Appearance**: Uses business email instead of generic admin email
3. **Better User Experience**: Customers contact the same email they receive communications from
4. **Reliable Fallback**: Always displays a valid email address even if WooCommerce email isn't configured
5. **Security**: Maintains existing security practices with proper escaping

## 🧪 Testing Instructions

### Prerequisites
- WooCommerce plugin active
- Access to WooCommerce settings

### Test Steps

1. **Configure WooCommerce Email Settings**:
   - Go to **WooCommerce → Settings → Emails**
   - Set the "From" email address to your business email
   - Save settings

2. **Test Thank You Page**:
   - Place a test order on the site
   - Complete the checkout process
   - Navigate to the thank-you page
   - Verify the support contact email matches your WooCommerce "from" email

3. **Test Fallback Behavior**:
   - Temporarily clear the WooCommerce "from" email setting
   - Refresh the thank-you page
   - Verify it falls back to the WordPress admin email
   - Restore the WooCommerce email setting

### Expected Results
- ✅ Thank-you page displays WooCommerce "from" email when configured
- ✅ Falls back to admin email when WooCommerce email is not set
- ✅ Email format is properly escaped and secure
- ✅ No visual or functional regressions on the thank-you page

## 📋 Checklist

- [x] Code follows project coding standards
- [x] Proper escaping maintained for security
- [x] Fallback strategy implemented for reliability
- [x] No breaking changes to existing functionality
- [x] Change is minimal and focused
- [x] Maintains backward compatibility

## 🔗 Related

- Addresses user request for WooCommerce email consistency
- Improves professional appearance of customer communications
- Aligns with WooCommerce best practices for email handling

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author