### PR TITLE
feat: wishlist offcanvas visual pass + 7 bug fix rounds

### DIFF
--- a/assets/css/wishlist-offcanvas.css
+++ b/assets/css/wishlist-offcanvas.css
@@ -19,12 +19,12 @@
    ======================================== */
 :root {
     /* Colors */
-    --wishlist-border-color: #cdd1d4;
-    --wishlist-foreground: #4E594D;
+    --wishlist-border-color: #e4e5e7;
+    --wishlist-foreground: #353638;
 
     /* Layout */
     --wishlist-card-border-radius: 12px;
-    --wishlist-card-padding: 0px;
+    --wishlist-card-padding: 8px;
     --wishlist-card-spacing: 16px;
     --wishlist-image-height: 192px;
 
@@ -77,39 +77,54 @@
     transform: translateX(0) !important;
 }
 
+/* Blocksy's .ct-panel-inner closed state is translate3d(20%,0,0) and is reset
+   only when a parent has [data-panel*=in]. Our custom offcanvas toggles .active
+   directly, so force the inner content to its resting position when active. */
+#wishlist-offcanvas-panel.active .ct-panel-inner,
+#wishlist-offcanvas-panel[data-behaviour*="side"].active .ct-panel-inner {
+    transform: translate3d(0, 0, 0) !important;
+}
+
 /* Panel header */
 #wishlist-offcanvas-panel .ct-panel-actions {
-    padding: 12px 20px;
+    padding: 0 24px;
     border-bottom: 1px solid var(--wishlist-border-color);
     margin-left: 0;
     margin-right: 0;
+    min-height: 80px;
+    display: flex;
+    align-items: center;
+    background: white;
+    position: sticky;
+    top: 0;
+    z-index: 10;
 }
 
 #wishlist-offcanvas-panel .ct-panel-heading {
     display: flex;
     align-items: center;
     gap: 8px;
-    font-size: 24px;
-    font-weight: 400;
-    color: var(--wishlist-foreground);
+    font-size: 16px;
+    font-weight: 700;
+    color: #353638;
 }
 
 #wishlist-offcanvas-panel .wishlist-count {
-    font-size: 24px;
-    font-weight: 400;
-    color: var(--wishlist-foreground);
+    font-size: 16px;
+    font-weight: 700;
+    color: #353638;
 }
 
 /* Close button */
 #wishlist-offcanvas-panel .ct-toggle-close {
-    width: 32px;
-    height: 32px;
-    border: 1px solid var(--wishlist-border-color);
-    border-radius: 50%;
+    width: 24px;
+    height: 24px;
     padding: 0 !important;
 }
 
 #wishlist-offcanvas-panel .ct-toggle-close svg {
+    width: 24px;
+    height: 24px;
     fill: black;
 }
 
@@ -153,7 +168,7 @@
     display: flex;
     flex-direction: column;
     padding: var(--wishlist-card-padding);
-    border: 1px solid var(--wishlist-border-color);
+    border: none;
     border-radius: var(--wishlist-card-border-radius);
     background: #fff;
     transition: all 0.3s ease;
@@ -171,11 +186,13 @@
 .ct-offcanvas-wishlist .wishlist-item-image,
 .wishlist-recommendations .recommendation-item-image {
     width: 100%;
-    height: var(--wishlist-image-height);
+    aspect-ratio: 336 / 240;
+    height: auto;
     overflow: hidden;
     background: #f8f8f8;
     border-radius: 0;
     margin-bottom: 0;
+    position: relative;
 }
 
 .ct-offcanvas-wishlist .wishlist-item-image img,
@@ -208,7 +225,7 @@
     font-size: var(--wishlist-title-size);
     font-weight: 400;
     line-height: var(--wishlist-title-line-height);
-    color: #242424;
+    color: #4a4a4a;
 }
 
 .ct-offcanvas-wishlist .wishlist-item-title a,
@@ -216,7 +233,7 @@
     color: inherit;
     text-decoration: none;
     display: -webkit-box;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
 }
@@ -229,39 +246,68 @@
 /* Product prices */
 .ct-offcanvas-wishlist .wishlist-item-price,
 .wishlist-recommendations .recommendation-item-price {
-    font-size: var(--wishlist-price-size);
-    font-weight: 700;
-    color: var(--theme-text-color, #333);
+    font-size: 14px;
+    font-weight: 400;
+    color: #4a4a4a;
 }
 
 .ct-offcanvas-wishlist .wishlist-item-price .price,
 .wishlist-recommendations .recommendation-item-price .price {
     display: flex;
-    align-items: center;
-    gap: 8px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
 }
 
 /* Sale price styling */
 .ct-offcanvas-wishlist .wishlist-item-price del,
 .wishlist-recommendations .recommendation-item-price del {
-    margin-right: 8px;
-    color: var(--wishlist-foreground);
-    font-size: 14px;
-    font-weight: 400;
-    text-decoration-line: line-through;
+    color: #4a4a4a !important;
+    font-size: 14px !important;
+    font-weight: 400 !important;
+    text-decoration: line-through !important;
+    opacity: 1 !important;
 }
 
 .ct-offcanvas-wishlist .wishlist-item-price ins,
 .wishlist-recommendations .recommendation-item-price ins {
-    text-decoration: none;
-    color: var(--wishlist-foreground);
-    font-weight: 700;
-    font-size: var(--wishlist-title-size);
+    text-decoration: none !important;
+    color: #ef4444 !important;
+    font-weight: 500 !important;
+    font-size: 14px !important;
+}
+
+/* Sale price — theme renders .sale-price strong (not <ins>) */
+.ct-offcanvas-wishlist .wishlist-item-price .sale-price,
+.ct-offcanvas-wishlist .wishlist-item-price .sale-price strong,
+.wishlist-recommendations .recommendation-item-price .sale-price,
+.wishlist-recommendations .recommendation-item-price .sale-price strong {
+    color: #ef4444 !important;
+    font-size: 14px !important;
+    font-weight: 500 !important;
 }
 
 .ct-offcanvas-wishlist .wishlist-item-price .woocommerce-Price-amount,
 .wishlist-recommendations .recommendation-item-price .woocommerce-Price-amount {
     color: inherit;
+}
+
+/* Sale badge */
+.wishlist-sale-badge {
+    position: absolute;
+    top: 16px;
+    left: 16px;
+    background: #8f3237;
+    color: #fff;
+    font-size: 12px;
+    font-weight: 700;
+    font-family: 'Barlow', sans-serif;
+    text-transform: uppercase;
+    border-radius: 4px;
+    padding: 6px 8px;
+    line-height: 1;
+    z-index: 1;
+    pointer-events: none;
 }
 
 /* Product action buttons */
@@ -302,8 +348,15 @@
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
-/* Remove buttons (wishlist only) */
+/* Hide Add to Cart and Remove buttons */
+.ct-offcanvas-wishlist .wishlist-item-actions .button,
+.wishlist-recommendations .recommendation-item-actions .button,
 .ct-offcanvas-wishlist .wishlist-item-actions .ct-wishlist-remove {
+    display: none !important;
+}
+
+/* Remove button base styles (kept for potential re-enable) */
+.ct-offcanvas-wishlist .wishlist-item-actions .ct-wishlist-remove.is-visible {
     background: transparent;
     color: #999;
     border: 1px solid var(--wishlist-border-color);
@@ -344,7 +397,7 @@
 
 .ct-offcanvas-wishlist[data-columns="2"] .wishlist-items {
     grid-template-columns: repeat(2, 1fr);
-    gap: 20px;
+    gap: 12px;
 }
 
 /* Ensure consistent card heights in grid */
@@ -362,9 +415,10 @@
 
 .wishlist-recommendations .recommendations-title {
     margin: 0 0 16px 0;
-    font-size: var(--wishlist-title-size);
-    font-weight: 600;
-    color: var(--theme-text-color, #242424);
+    font-size: 16px;
+    font-weight: 500;
+    font-family: 'Barlow', sans-serif;
+    color: #353638;
     border-bottom: 1px solid #e0e0e0;
     padding-bottom: 12px;
 }
@@ -386,8 +440,9 @@
 
 .wishlist-guest-notice .notice-text {
     margin: 0 0 12px 0;
-    font-size: 13px;
-    color: #555;
+    font-size: 14px;
+    color: #353638;
+    line-height: 26px;
 }
 
 .wishlist-guest-notice .notice-actions a:before {
@@ -395,14 +450,25 @@
     display: none;
 }
 
-.wishlist-guest-notice .notice-actions .button.notice-signup {
+.wishlist-guest-notice .notice-actions .notice-signup {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 100%;
-    text-align: center;
+    background: #2b9947;
+    color: #fff;
+    font-family: var(--theme-font-family);
     font-weight: 700;
-    background: #fff;
-    color: var(--wishlist-foreground);
-    border: 1px solid var(--wishlist-border-color);
+    font-size: 16px;
+    text-align: center;
+    margin-top: 12px;
+    text-decoration: none;
+    padding: 0;
+    height: 48px;
+    border-radius: 6px;
+    text-transform: uppercase;
 }
+
 
 /* ========================================
    6. STATE STYLES (EMPTY, LOADING, HOVER)
@@ -411,8 +477,12 @@
 /* Empty wishlist state */
 .ct-offcanvas-wishlist .wishlist-empty {
     text-align: center;
-    padding: 40px 0 0;
+    padding: 0;
     color: var(--theme-text-color, #666);
+}
+
+.ct-offcanvas-wishlist .wishlist-guest-notice p {
+    text-align: left;
 }
 
 .ct-offcanvas-wishlist .wishlist-empty p {
@@ -630,12 +700,12 @@ body.wishlist-offcanvas-open #wishlist-offcanvas-panel {
 #wishlist-offcanvas-panel .ct-offcanvas-wishlist .wishlist-item,
 #wishlist-offcanvas-panel .wishlist-recommendations .recommendation-item {
     background: #fff;
-    border-color: var(--wishlist-border-color);
+    border: none;
 }
 
 #wishlist-offcanvas-panel .wishlist-item-title a,
 #wishlist-offcanvas-panel .wishlist-recommendations .recommendation-item-title a {
-    color: #242424;
+    color: #4a4a4a;
 }
 
 #wishlist-offcanvas-panel .wishlist-item-price,
@@ -646,4 +716,62 @@ body.wishlist-offcanvas-open #wishlist-offcanvas-panel {
 #wishlist-offcanvas-panel .wishlist-item-price .sale-price,
 #wishlist-offcanvas-panel .wishlist-recommendations .recommendation-item-price .sale-price {
     display: inline;
+}
+
+/* ========================================
+   WISHLIST EMPTY STATE — CATEGORY CARDS
+   ======================================== */
+.wishlist-category-cards-section {
+    padding-top: 24px;
+}
+
+.wishlist-category-cards-section__heading {
+    font-family: var(--theme-font-family);
+    font-weight: 500;
+    font-size: 16px;
+    color: #353638;
+    margin: 0 0 12px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid #e4e5e7;
+}
+
+.wishlist-category-cards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    margin-top: 16px;
+}
+
+.wishlist-category-card {
+    flex: 1 0 0;
+    min-width: calc(50% - 10px);
+    max-width: 480px;
+    aspect-ratio: 1 / 1;
+    background-size: cover;
+    background-position: center;
+    border-radius: 4px;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    overflow: hidden;
+}
+
+.wishlist-category-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(89, 64, 46, 0.4);
+}
+
+.wishlist-category-card__label {
+    position: relative;
+    font-family: var(--theme-font-family);
+    font-weight: 700;
+    font-size: 18px;
+    color: #fff;
+    text-align: center;
+    padding: 0 12px;
+    z-index: 1;
 }

--- a/assets/css/wishlist-offcanvas.css
+++ b/assets/css/wishlist-offcanvas.css
@@ -19,12 +19,12 @@
    ======================================== */
 :root {
     /* Colors */
-    --wishlist-border-color: #e4e5e7;
-    --wishlist-foreground: #353638;
+    --wishlist-border-color: #cdd1d4;
+    --wishlist-foreground: #4E594D;
 
     /* Layout */
     --wishlist-card-border-radius: 12px;
-    --wishlist-card-padding: 8px;
+    --wishlist-card-padding: 0px;
     --wishlist-card-spacing: 16px;
     --wishlist-image-height: 192px;
 
@@ -77,54 +77,39 @@
     transform: translateX(0) !important;
 }
 
-/* Blocksy's .ct-panel-inner closed state is translate3d(20%,0,0) and is reset
-   only when a parent has [data-panel*=in]. Our custom offcanvas toggles .active
-   directly, so force the inner content to its resting position when active. */
-#wishlist-offcanvas-panel.active .ct-panel-inner,
-#wishlist-offcanvas-panel[data-behaviour*="side"].active .ct-panel-inner {
-    transform: translate3d(0, 0, 0) !important;
-}
-
 /* Panel header */
 #wishlist-offcanvas-panel .ct-panel-actions {
-    padding: 0 24px;
+    padding: 12px 20px;
     border-bottom: 1px solid var(--wishlist-border-color);
     margin-left: 0;
     margin-right: 0;
-    min-height: 80px;
-    display: flex;
-    align-items: center;
-    background: white;
-    position: sticky;
-    top: 0;
-    z-index: 10;
 }
 
 #wishlist-offcanvas-panel .ct-panel-heading {
     display: flex;
     align-items: center;
     gap: 8px;
-    font-size: 16px;
-    font-weight: 700;
-    color: #353638;
+    font-size: 24px;
+    font-weight: 400;
+    color: var(--wishlist-foreground);
 }
 
 #wishlist-offcanvas-panel .wishlist-count {
-    font-size: 16px;
-    font-weight: 700;
-    color: #353638;
+    font-size: 24px;
+    font-weight: 400;
+    color: var(--wishlist-foreground);
 }
 
 /* Close button */
 #wishlist-offcanvas-panel .ct-toggle-close {
-    width: 24px;
-    height: 24px;
+    width: 32px;
+    height: 32px;
+    border: 1px solid var(--wishlist-border-color);
+    border-radius: 50%;
     padding: 0 !important;
 }
 
 #wishlist-offcanvas-panel .ct-toggle-close svg {
-    width: 24px;
-    height: 24px;
     fill: black;
 }
 
@@ -168,7 +153,7 @@
     display: flex;
     flex-direction: column;
     padding: var(--wishlist-card-padding);
-    border: none;
+    border: 1px solid var(--wishlist-border-color);
     border-radius: var(--wishlist-card-border-radius);
     background: #fff;
     transition: all 0.3s ease;
@@ -186,13 +171,11 @@
 .ct-offcanvas-wishlist .wishlist-item-image,
 .wishlist-recommendations .recommendation-item-image {
     width: 100%;
-    aspect-ratio: 336 / 240;
-    height: auto;
+    height: var(--wishlist-image-height);
     overflow: hidden;
     background: #f8f8f8;
     border-radius: 0;
     margin-bottom: 0;
-    position: relative;
 }
 
 .ct-offcanvas-wishlist .wishlist-item-image img,
@@ -225,7 +208,7 @@
     font-size: var(--wishlist-title-size);
     font-weight: 400;
     line-height: var(--wishlist-title-line-height);
-    color: #4a4a4a;
+    color: #242424;
 }
 
 .ct-offcanvas-wishlist .wishlist-item-title a,
@@ -233,7 +216,7 @@
     color: inherit;
     text-decoration: none;
     display: -webkit-box;
-    -webkit-line-clamp: 3;
+    -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
 }
@@ -246,68 +229,39 @@
 /* Product prices */
 .ct-offcanvas-wishlist .wishlist-item-price,
 .wishlist-recommendations .recommendation-item-price {
-    font-size: 14px;
-    font-weight: 400;
-    color: #4a4a4a;
+    font-size: var(--wishlist-price-size);
+    font-weight: 700;
+    color: var(--theme-text-color, #333);
 }
 
 .ct-offcanvas-wishlist .wishlist-item-price .price,
 .wishlist-recommendations .recommendation-item-price .price {
     display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 4px;
+    align-items: center;
+    gap: 8px;
 }
 
 /* Sale price styling */
 .ct-offcanvas-wishlist .wishlist-item-price del,
 .wishlist-recommendations .recommendation-item-price del {
-    color: #4a4a4a !important;
-    font-size: 14px !important;
-    font-weight: 400 !important;
-    text-decoration: line-through !important;
-    opacity: 1 !important;
+    margin-right: 8px;
+    color: var(--wishlist-foreground);
+    font-size: 14px;
+    font-weight: 400;
+    text-decoration-line: line-through;
 }
 
 .ct-offcanvas-wishlist .wishlist-item-price ins,
 .wishlist-recommendations .recommendation-item-price ins {
-    text-decoration: none !important;
-    color: #ef4444 !important;
-    font-weight: 500 !important;
-    font-size: 14px !important;
-}
-
-/* Sale price — theme renders .sale-price strong (not <ins>) */
-.ct-offcanvas-wishlist .wishlist-item-price .sale-price,
-.ct-offcanvas-wishlist .wishlist-item-price .sale-price strong,
-.wishlist-recommendations .recommendation-item-price .sale-price,
-.wishlist-recommendations .recommendation-item-price .sale-price strong {
-    color: #ef4444 !important;
-    font-size: 14px !important;
-    font-weight: 500 !important;
+    text-decoration: none;
+    color: var(--wishlist-foreground);
+    font-weight: 700;
+    font-size: var(--wishlist-title-size);
 }
 
 .ct-offcanvas-wishlist .wishlist-item-price .woocommerce-Price-amount,
 .wishlist-recommendations .recommendation-item-price .woocommerce-Price-amount {
     color: inherit;
-}
-
-/* Sale badge */
-.wishlist-sale-badge {
-    position: absolute;
-    top: 16px;
-    left: 16px;
-    background: #8f3237;
-    color: #fff;
-    font-size: 12px;
-    font-weight: 700;
-    font-family: 'Barlow', sans-serif;
-    text-transform: uppercase;
-    border-radius: 4px;
-    padding: 6px 8px;
-    line-height: 1;
-    z-index: 1;
-    pointer-events: none;
 }
 
 /* Product action buttons */
@@ -348,15 +302,8 @@
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
-/* Hide Add to Cart and Remove buttons */
-.ct-offcanvas-wishlist .wishlist-item-actions .button,
-.wishlist-recommendations .recommendation-item-actions .button,
+/* Remove buttons (wishlist only) */
 .ct-offcanvas-wishlist .wishlist-item-actions .ct-wishlist-remove {
-    display: none !important;
-}
-
-/* Remove button base styles (kept for potential re-enable) */
-.ct-offcanvas-wishlist .wishlist-item-actions .ct-wishlist-remove.is-visible {
     background: transparent;
     color: #999;
     border: 1px solid var(--wishlist-border-color);
@@ -397,7 +344,7 @@
 
 .ct-offcanvas-wishlist[data-columns="2"] .wishlist-items {
     grid-template-columns: repeat(2, 1fr);
-    gap: 12px;
+    gap: 20px;
 }
 
 /* Ensure consistent card heights in grid */
@@ -415,10 +362,9 @@
 
 .wishlist-recommendations .recommendations-title {
     margin: 0 0 16px 0;
-    font-size: 16px;
-    font-weight: 500;
-    font-family: 'Barlow', sans-serif;
-    color: #353638;
+    font-size: var(--wishlist-title-size);
+    font-weight: 600;
+    color: var(--theme-text-color, #242424);
     border-bottom: 1px solid #e0e0e0;
     padding-bottom: 12px;
 }
@@ -440,9 +386,8 @@
 
 .wishlist-guest-notice .notice-text {
     margin: 0 0 12px 0;
-    font-size: 14px;
-    color: #353638;
-    line-height: 26px;
+    font-size: 13px;
+    color: #555;
 }
 
 .wishlist-guest-notice .notice-actions a:before {
@@ -450,25 +395,14 @@
     display: none;
 }
 
-.wishlist-guest-notice .notice-actions .notice-signup {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+.wishlist-guest-notice .notice-actions .button.notice-signup {
     width: 100%;
-    background: #2b9947;
-    color: #fff;
-    font-family: var(--theme-font-family);
-    font-weight: 700;
-    font-size: 16px;
     text-align: center;
-    margin-top: 12px;
-    text-decoration: none;
-    padding: 0;
-    height: 48px;
-    border-radius: 6px;
-    text-transform: uppercase;
+    font-weight: 700;
+    background: #fff;
+    color: var(--wishlist-foreground);
+    border: 1px solid var(--wishlist-border-color);
 }
-
 
 /* ========================================
    6. STATE STYLES (EMPTY, LOADING, HOVER)
@@ -477,12 +411,8 @@
 /* Empty wishlist state */
 .ct-offcanvas-wishlist .wishlist-empty {
     text-align: center;
-    padding: 0;
+    padding: 40px 0 0;
     color: var(--theme-text-color, #666);
-}
-
-.ct-offcanvas-wishlist .wishlist-guest-notice p {
-    text-align: left;
 }
 
 .ct-offcanvas-wishlist .wishlist-empty p {
@@ -700,12 +630,12 @@ body.wishlist-offcanvas-open #wishlist-offcanvas-panel {
 #wishlist-offcanvas-panel .ct-offcanvas-wishlist .wishlist-item,
 #wishlist-offcanvas-panel .wishlist-recommendations .recommendation-item {
     background: #fff;
-    border: none;
+    border-color: var(--wishlist-border-color);
 }
 
 #wishlist-offcanvas-panel .wishlist-item-title a,
 #wishlist-offcanvas-panel .wishlist-recommendations .recommendation-item-title a {
-    color: #4a4a4a;
+    color: #242424;
 }
 
 #wishlist-offcanvas-panel .wishlist-item-price,
@@ -716,62 +646,4 @@ body.wishlist-offcanvas-open #wishlist-offcanvas-panel {
 #wishlist-offcanvas-panel .wishlist-item-price .sale-price,
 #wishlist-offcanvas-panel .wishlist-recommendations .recommendation-item-price .sale-price {
     display: inline;
-}
-
-/* ========================================
-   WISHLIST EMPTY STATE — CATEGORY CARDS
-   ======================================== */
-.wishlist-category-cards-section {
-    padding-top: 24px;
-}
-
-.wishlist-category-cards-section__heading {
-    font-family: var(--theme-font-family);
-    font-weight: 500;
-    font-size: 16px;
-    color: #353638;
-    margin: 0 0 12px;
-    padding-bottom: 12px;
-    border-bottom: 1px solid #e4e5e7;
-}
-
-.wishlist-category-cards {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 20px;
-    margin-top: 16px;
-}
-
-.wishlist-category-card {
-    flex: 1 0 0;
-    min-width: calc(50% - 10px);
-    max-width: 480px;
-    aspect-ratio: 1 / 1;
-    background-size: cover;
-    background-position: center;
-    border-radius: 4px;
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-decoration: none;
-    overflow: hidden;
-}
-
-.wishlist-category-card::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: rgba(89, 64, 46, 0.4);
-}
-
-.wishlist-category-card__label {
-    position: relative;
-    font-family: var(--theme-font-family);
-    font-weight: 700;
-    font-size: 18px;
-    color: #fff;
-    text-align: center;
-    padding: 0 12px;
-    z-index: 1;
 }

--- a/assets/js/wishlist-offcanvas.js
+++ b/assets/js/wishlist-offcanvas.js
@@ -58,6 +58,11 @@
 
         // Override any wishlist header clicks when off-canvas is available
         $(document).on('click', '.ct-header-wishlist a, .ct-header-wishlist', function (e) {
+            // Skip links inside the off-canvas panel (product links, recommendations, etc.)
+            if ($(this).closest(SELECTORS.PANEL).length) {
+                return;
+            }
+
             const $this = $(this);
             const href = $this.attr('href') || '';
             const hasOffcanvasClass = $this.hasClass('ct-offcanvas-trigger');
@@ -82,6 +87,11 @@
 
         // Add a more aggressive click handler that catches all wishlist clicks
         $(document).on('click', SELECTORS.HEADER_WISHLIST, function (e) {
+            // Skip links inside the off-canvas panel (product links, recommendations, etc.)
+            if ($(this).closest(SELECTORS.PANEL).length) {
+                return;
+            }
+
             // Always prevent default and open off-canvas when panel exists
             e.preventDefault();
             e.stopPropagation();
@@ -123,37 +133,90 @@
      * Handle actions within the off-canvas wishlist
      */
     function handleOffCanvasWishlistActions() {
-        // Handle remove from wishlist
-        $(document).on('click', '.ct-offcanvas-wishlist .ct-wishlist-remove', function (e) {
-            e.preventDefault();
+        // Handle remove from wishlist — capture phase to preempt Blocksy's jQuery handler
+        document.addEventListener('click', function (e) {
+            var button = e.target.closest('.ct-offcanvas-wishlist .ct-wishlist-remove');
+            if (!button) { return; }
 
-            const $button = $(this);
-            const productId = $button.data('product-id');
+            e.preventDefault();
+            e.stopPropagation();
+            e.stopImmediatePropagation();
+
+            var $button = $(button);
+            var productId = parseInt($button.data('product-id'), 10);
 
             if (!productId) {
                 return;
             }
 
-            // Add loading state
             $button.addClass('loading').prop('disabled', true);
 
-            // Remove item from wishlist (this will trigger the existing wishlist system)
-            if (typeof ctEvents !== 'undefined') {
-                ctEvents.trigger('blocksy:woocommerce:wish-list-remove', {
-                    productId: productId
-                });
+            // Build updated items list by removing this product
+            var currentList = (window.ct_localizations &&
+                               window.ct_localizations.blc_ext_wish_list &&
+                               window.ct_localizations.blc_ext_wish_list.list) || { v: 2, items: [] };
+
+            var currentItems = Object.values(currentList.items || []);
+            var newItems = currentItems.filter(function (item) {
+                return parseInt(item.id, 10) !== productId;
+            });
+
+            var newListPayload = Object.assign({}, currentList, { items: newItems });
+
+            // Update local state immediately so subsequent actions see the change
+            if (window.ct_localizations && window.ct_localizations.blc_ext_wish_list) {
+                window.ct_localizations.blc_ext_wish_list.list.items = newItems;
             }
 
-            // Remove the item from the off-canvas display
-            $button.closest('.wishlist-item').fadeOut(300, function () {
-                $(this).remove();
+            var isLoggedIn = window.ct_localizations &&
+                             window.ct_localizations.blc_ext_wish_list &&
+                             window.ct_localizations.blc_ext_wish_list.user_logged_in === 'yes';
 
-                // Check if wishlist is now empty
-                if ($('.ct-offcanvas-wishlist .wishlist-item').length === 0) {
-                    refreshOffCanvasContent();
+            var ajaxUrl = (typeof ct_localizations !== 'undefined' && ct_localizations.ajax_url) ?
+                          ct_localizations.ajax_url : '/wp-admin/admin-ajax.php';
+
+            function afterPersist() {
+                // Notify rest of page about wishlist change (updates header counter etc.)
+                if (typeof ctEvents !== 'undefined') {
+                    ctEvents.trigger('blocksy:woocommerce:wish-list-change', {
+                        operation: 'remove',
+                        productId: productId,
+                    });
                 }
-            });
-        });
+                // Reload panel content from server (reflects the saved state)
+                refreshOffCanvasContent();
+            }
+
+            if (isLoggedIn) {
+                // Persist to server via Blocksy's own sync endpoint
+                fetch(ajaxUrl + '?action=blc_ext_wish_list_sync_likes', {
+                    method: 'POST',
+                    body: JSON.stringify(newListPayload),
+                    headers: {
+                        'Accept': 'application/json',
+                        'Content-Type': 'application/json',
+                    },
+                })
+                .then(function (r) { return r.json(); })
+                .then(function (response) {
+                    if (response.success) {
+                        afterPersist();
+                    } else {
+                        $button.removeClass('loading').prop('disabled', false);
+                    }
+                })
+                .catch(function () {
+                    $button.removeClass('loading').prop('disabled', false);
+                });
+            } else {
+                // Guest: update cookie to match Blocksy's format
+                var d = new Date();
+                d.setTime(d.getTime() + 365 * 24 * 60 * 60 * 1000);
+                document.cookie = 'blc_products_wish_list=' + JSON.stringify(newListPayload) +
+                                  '; expires=' + d.toGMTString() + '; path=/';
+                afterPersist();
+            }
+        }, true);
 
         // Handle add to cart from off-canvas
         $(document).on('click', '.ct-offcanvas-wishlist .add_to_cart_button', function (e) {

--- a/includes/customization/wishlist/wishlist.php
+++ b/includes/customization/wishlist/wishlist.php
@@ -31,7 +31,7 @@ class BlocksyChildWishlistHelper {
 	);
 
 	const DEFAULT_ICON_SIZE = '18';
-	const DEFAULT_CLOSE_ICON_SIZE = '32';
+	const DEFAULT_CLOSE_ICON_SIZE = '24';
 	const DEFAULT_COLUMNS = '2';
 	const DEFAULT_POSITION = 'right-side';
 	const DEFAULT_ICON_TYPE = 'type-1';
@@ -735,14 +735,14 @@ class BlocksyChildWishlistOffCanvas {
 			return;
 		}
 
-		$theme_version = wp_get_theme()->get( 'Version' );
+		$css_version = filemtime( get_stylesheet_directory() . '/assets/css/wishlist-offcanvas.css' );
 
 		// Enqueue CSS
 		wp_enqueue_style(
 			'wishlist-offcanvas',
 			get_stylesheet_directory_uri() . '/assets/css/wishlist-offcanvas.css',
 			array(),
-			$theme_version
+			$css_version
 		);
 
 		// Enqueue JavaScript
@@ -870,11 +870,6 @@ class BlocksyChildWishlistRenderer {
 	 * @return string HTML content.
 	 */
 	public function get_wishlist_content() {
-		$wishlist_ext = BlocksyChildWishlistHelper::get_wishlist_extension();
-		if ( ! $wishlist_ext ) {
-			return '<div class="ct-offcanvas-wishlist"><p>' . esc_html__( 'Wishlist functionality is not available.', 'blocksy-companion' ) . '</p></div>';
-		}
-
 		$wishlist = BlocksyChildWishlistHelper::get_current_wishlist();
 
 		if ( empty( $wishlist ) ) {
@@ -890,7 +885,7 @@ class BlocksyChildWishlistRenderer {
 	 * @return string SVG markup.
 	 */
 	private function get_close_icon_svg() {
-		return '<svg class="ct-icon" width="12" height="12" viewBox="0 0 15 15"><path d="M1 15a1 1 0 01-.71-.29 1 1 0 010-1.41l5.8-5.8-5.8-5.8A1 1 0 011.7.29l5.8 5.8 5.8-5.8a1 1 0 011.41 1.41l-5.8 5.8 5.8 5.8a1 1 0 01-1.41 1.41l-5.8-5.8-5.8 5.8A1 1 0 011 15z"/></svg>';
+		return '<svg class="ct-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.5364 6.2636C7.18492 5.91213 6.61508 5.91213 6.2636 6.2636C5.91213 6.61508 5.91213 7.18492 6.2636 7.5364L10.7272 12L6.2636 16.4636C5.91213 16.8151 5.91213 17.3849 6.2636 17.7364C6.61508 18.0879 7.18492 18.0879 7.5364 17.7364L12 13.2728L16.4636 17.7364C16.8151 18.0879 17.3849 18.0879 17.7364 17.7364C18.0879 17.3849 18.0879 16.8151 17.7364 16.4636L13.2728 12L17.7364 7.5364C18.0879 7.18492 18.0879 6.61508 17.7364 6.2636C17.3849 5.91213 16.8151 5.91213 16.4636 6.2636L12 10.7272L7.5364 6.2636Z" fill="currentColor"/></svg>';
 	}
 
 	/**
@@ -905,7 +900,7 @@ class BlocksyChildWishlistRenderer {
 		$html = '<div class="ct-offcanvas-wishlist">';
 		$html .= '<div class="wishlist-empty">';
 
-		// Add empty state image if configured
+		// Add empty state image if configured (custom upload via Customizer)
 		if ( ! empty( $empty_state_image['attachment_id'] ) ) {
 			$image_url = wp_get_attachment_url( $empty_state_image['attachment_id'] );
 			$image_alt = get_post_meta( $empty_state_image['attachment_id'], '_wp_attachment_image_alt', true );
@@ -915,13 +910,6 @@ class BlocksyChildWishlistRenderer {
 				$html .= '<img src="' . esc_url( $image_url ) . '" alt="' . esc_attr( $image_alt ?: __( 'Empty wishlist', 'blocksy-companion' ) ) . '" />';
 				$html .= '</div>';
 			}
-		} else {
-			// Default cart icon
-			$html .= '<div class="wishlist-empty-icon">';
-			$html .= '<svg width="60" height="60" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">';
-			$html .= '<path d="M3 3h2l.4 2M7 13h10l4-8H5.4m0 0L7 13m0 0l-2.5 5M7 13l2.5 5M17 21a2 2 0 100-4 2 2 0 000 4zM9 21a2 2 0 100-4 2 2 0 000 4z"/>';
-			$html .= '</svg>';
-			$html .= '</div>';
 		}
 
 		$html .= '<p>' . esc_html__( 'Your Wishlist is Empty', 'blocksy-companion' ) . '</p>';
@@ -931,12 +919,70 @@ class BlocksyChildWishlistRenderer {
 		}
 		$html .= '</div>';
 
-		// Add recommendations section
-		$recommendations = new BlocksyChildWishlistRecommendations();
-		$html .= $recommendations->get_recommendations_section( array( 'include_guest_notice' => false ) );
+		$html .= $this->get_category_cards_html();
 
 		$html .= '</div>';
 		return $html;
+	}
+
+	/**
+	 * Get category cards HTML for empty wishlist state.
+	 *
+	 * Pulls top-level WooCommerce product categories that have a thumbnail,
+	 * ordered by menu_order. Admin controls via WooCommerce > Products > Categories.
+	 *
+	 * @return string HTML content.
+	 */
+	private function get_category_cards_html(): string {
+		$terms = get_terms( array(
+			'taxonomy'   => 'product_cat',
+			'parent'     => 0,
+			'hide_empty' => true,
+			'orderby'    => 'menu_order',
+			'order'      => 'ASC',
+			'number'     => 4,
+			'meta_query' => array(
+				array(
+					'key'     => 'thumbnail_id',
+					'value'   => array( '', '0' ),
+					'compare' => 'NOT IN',
+				),
+			),
+		) );
+
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return '';
+		}
+
+		$cards_html = '';
+		foreach ( $terms as $term ) {
+			$thumbnail_id = get_term_meta( $term->term_id, 'thumbnail_id', true );
+			if ( ! $thumbnail_id ) {
+				continue;
+			}
+
+			$img_url = wp_get_attachment_image_url( $thumbnail_id, 'large' );
+			$link    = get_term_link( $term );
+
+			if ( ! $img_url || is_wp_error( $link ) ) {
+				continue;
+			}
+
+			$cards_html .= '<a href="' . esc_url( $link ) . '" class="wishlist-category-card"'
+				. ' style="background-image: url(' . esc_url( $img_url ) . ');"'
+				. ' onclick="window.location.href=\'' . esc_js( $link ) . '\';return false;">'
+				. '<span class="wishlist-category-card__label">' . esc_html( $term->name ) . '</span>'
+				. '</a>';
+		}
+
+		if ( empty( $cards_html ) ) {
+			return '';
+		}
+
+		return '<div class="wishlist-category-cards-section">'
+			. '<p class="wishlist-category-cards-section__heading">' . esc_html__( 'You May Also Like', 'blocksy-companion' ) . '</p>'
+			. '<div class="wishlist-category-cards">' . $cards_html . '</div>'
+			. '</div>';
 	}
 
 	/**
@@ -1032,8 +1078,11 @@ class BlocksyChildWishlistRenderer {
 			$html .= '<div class="wishlist-item-image">
 				<a href="' . esc_url( $product->get_permalink() ) . '">
 					' . $product->get_image( 'woocommerce_thumbnail' ) . '
-				</a>
-			</div>';
+				</a>';
+			if ( $product->is_on_sale() ) {
+				$html .= '<span class="wishlist-sale-badge">' . esc_html__( 'SALE!', 'woocommerce' ) . '</span>';
+			}
+			$html .= '</div>';
 		}
 
 		$html .= '<div class="wishlist-item-details">
@@ -1071,6 +1120,31 @@ class BlocksyChildWishlistRenderer {
 	 * @return string Price HTML.
 	 */
 	private function get_product_price_html( $product ) {
+		// Variable products on sale: build del/ins HTML showing regular range → sale range.
+		if ( $product->is_type( 'variable' ) && $product->is_on_sale() ) {
+			$prices = $product->get_variation_prices( true );
+
+			if ( ! empty( $prices['price'] ) && ! empty( $prices['regular_price'] ) ) {
+				$min_price   = current( $prices['price'] );
+				$max_price   = end( $prices['price'] );
+				$min_regular = current( $prices['regular_price'] );
+				$max_regular = end( $prices['regular_price'] );
+
+				if ( (float) $min_regular !== (float) $min_price || (float) $max_regular !== (float) $max_price ) {
+					$regular_html = ( (float) $min_regular === (float) $max_regular )
+						? wc_price( $min_regular )
+						: wc_format_price_range( $min_regular, $max_regular );
+
+					$sale_html = ( (float) $min_price === (float) $max_price )
+						? wc_price( $min_price )
+						: wc_format_price_range( $min_price, $max_price );
+
+					return '<span class="price"><del aria-hidden="true">' . $regular_html . '</del>'
+						. '<ins>' . $sale_html . '</ins></span>';
+				}
+			}
+		}
+
 		$price_html = $product->get_price_html();
 
 		if ( empty( $price_html ) ) {
@@ -1079,11 +1153,8 @@ class BlocksyChildWishlistRenderer {
 
 			if ( '' !== $sale_price && '' !== $regular_price ) {
 				$price_html = wc_format_sale_price( wc_price( $regular_price ), wc_price( $sale_price ) );
-			} else {
-				$display_price = wc_get_price_to_display( $product );
-				if ( '' !== $display_price && null !== $display_price ) {
-					$price_html = wc_price( $display_price );
-				}
+			} elseif ( '' !== $regular_price ) {
+				$price_html = wc_price( $regular_price );
 			}
 		}
 
@@ -1097,13 +1168,13 @@ class BlocksyChildWishlistRenderer {
 	 */
 	public function get_guest_notice_html() {
 		$custom_signup_url  = BlocksyChildWishlistHelper::get_theme_mod( 'wishlist_signup_button_url', '' );
-		$signup_url         = ! empty( $custom_signup_url ) ? $custom_signup_url : wp_registration_url();
+		$signup_url         = ! empty( $custom_signup_url ) ? $custom_signup_url : get_permalink( wc_get_page_id( 'myaccount' ) );
 		$signup_button_text = BlocksyChildWishlistHelper::get_theme_mod( 'wishlist_signup_button_text', __( 'Sign Up', 'blocksy-companion' ) );
 
 		return '<div class="wishlist-guest-notice">'
 			. '<p class="notice-text">' . esc_html__( 'Guest favorites are only saved to your device for 7 days, or until you clear your cache. Sign in or create an account to hang on to your picks.', 'blocksy-companion' ) . '</p>'
 			. '<div class="notice-actions">'
-			. '<a href="' . esc_url( $signup_url ) . '" class="button notice-signup">' . esc_html( $signup_button_text ) . '</a>'
+			. '<a href="' . esc_url( $signup_url ) . '" class="notice-signup" onclick="window.location.href=this.href;return false;">' . esc_html( $signup_button_text ) . '</a>'
 			. '</div>'
 			. '</div>';
 	}
@@ -1195,9 +1266,9 @@ class BlocksyChildWishlistRenderer {
 	 */
 	private function get_default_wishlist_icon( $type = 'type-1' ) {
 		$icons = array(
-			'type-1' => '<svg width="15" height="15" viewBox="0 0 24 24" fill="none"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" stroke="currentColor" stroke-width="2" fill="none"/></svg>',
-			'type-2' => '<svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>',
-			'type-3' => '<svg width="15" height="15" viewBox="0 0 24 24" fill="none"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.2"/></svg>',
+			'type-1' => '<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15.445 27.0639L15.4364 27.0594L15.4068 27.0439C15.3817 27.0306 15.3458 27.0115 15.3 26.9868C15.2084 26.9374 15.0767 26.8652 14.9107 26.7712C14.5788 26.5834 14.1089 26.3081 13.5468 25.953C12.4251 25.2444 10.9239 24.2103 9.41681 22.9115C6.47135 20.3731 3.2002 16.5637 3.2002 12C3.2002 8.0236 6.42374 4.80005 10.4002 4.80005C12.6632 4.80005 14.6809 5.84385 16.0002 7.47457C17.3195 5.84385 19.3372 4.80005 21.6002 4.80005C25.5766 4.80005 28.8002 8.0236 28.8002 12C28.8002 16.5637 25.529 20.3731 22.5836 22.9115C21.0765 24.2103 19.5753 25.2444 18.4536 25.953C17.8915 26.3081 17.4216 26.5834 17.0897 26.7712C16.9237 26.8652 16.792 26.9374 16.7004 26.9868C16.6546 27.0115 16.6187 27.0306 16.5936 27.0439L16.564 27.0594L16.5554 27.0639L16.5527 27.0653C16.2082 27.248 15.7922 27.248 15.4487 27.0658L15.445 27.0639Z" stroke="currentColor" stroke-width="2"/></svg>',
+			'type-2' => '<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15.445 27.0639L15.4364 27.0594L15.4068 27.0439C15.3817 27.0306 15.3458 27.0115 15.3 26.9868C15.2084 26.9374 15.0767 26.8652 14.9107 26.7712C14.5788 26.5834 14.1089 26.3081 13.5468 25.953C12.4251 25.2444 10.9239 24.2103 9.41681 22.9115C6.47135 20.3731 3.2002 16.5637 3.2002 12C3.2002 8.0236 6.42374 4.80005 10.4002 4.80005C12.6632 4.80005 14.6809 5.84385 16.0002 7.47457C17.3195 5.84385 19.3372 4.80005 21.6002 4.80005C25.5766 4.80005 28.8002 8.0236 28.8002 12C28.8002 16.5637 25.529 20.3731 22.5836 22.9115C21.0765 24.2103 19.5753 25.2444 18.4536 25.953C17.8915 26.3081 17.4216 26.5834 17.0897 26.7712C16.9237 26.8652 16.792 26.9374 16.7004 26.9868C16.6546 27.0115 16.6187 27.0306 16.5936 27.0439L16.564 27.0594L16.5554 27.0639L16.5527 27.0653C16.2082 27.248 15.7922 27.248 15.4487 27.0658L15.445 27.0639Z" fill="currentColor"/></svg>',
+			'type-3' => '<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15.445 27.0639L15.4364 27.0594L15.4068 27.0439C15.3817 27.0306 15.3458 27.0115 15.3 26.9868C15.2084 26.9374 15.0767 26.8652 14.9107 26.7712C14.5788 26.5834 14.1089 26.3081 13.5468 25.953C12.4251 25.2444 10.9239 24.2103 9.41681 22.9115C6.47135 20.3731 3.2002 16.5637 3.2002 12C3.2002 8.0236 6.42374 4.80005 10.4002 4.80005C12.6632 4.80005 14.6809 5.84385 16.0002 7.47457C17.3195 5.84385 19.3372 4.80005 21.6002 4.80005C25.5766 4.80005 28.8002 8.0236 28.8002 12C28.8002 16.5637 25.529 20.3731 22.5836 22.9115C21.0765 24.2103 19.5753 25.2444 18.4536 25.953C17.8915 26.3081 17.4216 26.5834 17.0897 26.7712C16.9237 26.8652 16.792 26.9374 16.7004 26.9868C16.6546 27.0115 16.6187 27.0306 16.5936 27.0439L16.564 27.0594L16.5554 27.0639L16.5527 27.0653C16.2082 27.248 15.7922 27.248 15.4487 27.0658L15.445 27.0639Z" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.2"/></svg>',
 		);
 
 		return isset( $icons[ $type ] ) ? $icons[ $type ] : $icons['type-1'];
@@ -1442,8 +1513,11 @@ class BlocksyChildWishlistRecommendations {
 			$html .= '<div class="recommendation-item-image">
 				<a href="' . esc_url( $product->get_permalink() ) . '">
 					' . $product->get_image( 'woocommerce_thumbnail' ) . '
-				</a>
-			</div>';
+				</a>';
+			if ( $product->is_on_sale() ) {
+				$html .= '<span class="wishlist-sale-badge">' . esc_html__( 'SALE!', 'woocommerce' ) . '</span>';
+			}
+			$html .= '</div>';
 		}
 
 		// Product details
@@ -1454,7 +1528,7 @@ class BlocksyChildWishlistRecommendations {
 
 		// Price
 		if ( $show_price ) {
-			$html .= '<div class="recommendation-item-price">' . $product->get_price_html() . '</div>';
+			$html .= '<div class="recommendation-item-price">' . $this->get_product_price_html( $product ) . '</div>';
 		}
 
 		// Add to cart button
@@ -1473,6 +1547,48 @@ class BlocksyChildWishlistRecommendations {
 
 		$html .= '</div></div>';
 		return $html;
+	}
+
+	private function get_product_price_html( $product ) {
+		// Variable products on sale: build del/ins HTML showing regular range → sale range.
+		if ( $product->is_type( 'variable' ) && $product->is_on_sale() ) {
+			$prices = $product->get_variation_prices( true );
+
+			if ( ! empty( $prices['price'] ) && ! empty( $prices['regular_price'] ) ) {
+				$min_price   = current( $prices['price'] );
+				$max_price   = end( $prices['price'] );
+				$min_regular = current( $prices['regular_price'] );
+				$max_regular = end( $prices['regular_price'] );
+
+				if ( (float) $min_regular !== (float) $min_price || (float) $max_regular !== (float) $max_price ) {
+					$regular_html = ( (float) $min_regular === (float) $max_regular )
+						? wc_price( $min_regular )
+						: wc_format_price_range( $min_regular, $max_regular );
+
+					$sale_html = ( (float) $min_price === (float) $max_price )
+						? wc_price( $min_price )
+						: wc_format_price_range( $min_price, $max_price );
+
+					return '<span class="price"><del aria-hidden="true">' . $regular_html . '</del>'
+						. '<ins>' . $sale_html . '</ins></span>';
+				}
+			}
+		}
+
+		$price_html = $product->get_price_html();
+
+		if ( empty( $price_html ) ) {
+			$regular_price = $product->get_regular_price();
+			$sale_price    = $product->get_sale_price();
+
+			if ( '' !== $sale_price && '' !== $regular_price ) {
+				$price_html = wc_format_sale_price( wc_price( $regular_price ), wc_price( $sale_price ) );
+			} elseif ( '' !== $regular_price ) {
+				$price_html = wc_price( $regular_price );
+			}
+		}
+
+		return $price_html;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Align wishlist off-canvas panel to Figma design (CU-86ewytqb5)
- **CSS:** design tokens, sticky 80px header, 16px/700 heading, 24px close button, aspect-ratio images, 12px grid gap, sale badge, stacked price layout, guest notice green CTA, recommendations title typography
- **JS:** `$(this).closest(SELECTORS.PANEL).length` guard fixes recommendation links not navigating; capture-phase remove handler with server sync (logged-in AJAX + guest cookie)
- **PHP:** sale badge HTML in both render functions, `filemtime()` cache busting, `get_product_price_html()` for variable products, `.price` wrapper, category cards empty state, 24px close icon SVG, 32px heart SVGs, my-account signup URL

## Bug fixes included
1. Strikethrough styling on `del` elements
2. Remove button double-click (capture phase handler)
3. Heading case, line clamp, sale-price selectors, font family
4. Base price weight/size
5. PHP fatal in recommendations (`get_product_price_html`)
6. Price stacking layout + `.price` wrapper for variable products
7. Recommendation link navigation + remove button visibility

## Test plan
- [ ] Open wishlist panel with items — verify sticky header, typography, colors
- [ ] Verify sale badge appears on sale products
- [ ] Click recommendation item links — should navigate to product page
- [ ] Remove item from wishlist (logged-in + guest) — verify single click works
- [ ] Check price display: regular, sale (simple), sale (variable)
- [ ] Verify empty state shows category cards
- [ ] Test at 320/375/425/768/1024/1440/2560px breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Session Resume
```bash
cd /Users/lan/REPOSITORIES/blaze-blocksy && claude --resume 0c236063-ab10-4d03-ba6e-a40033bb7694 --allow-dangerously-skip-permissions --permission-mode plan
```