### PR TITLE
fix: resend email button as inline underlined text link

### DIFF
--- a/assets/css/thank-you.css
+++ b/assets/css/thank-you.css
@@ -1071,32 +1071,37 @@
 }
 
 
-/* Transparent button styling - improved specificity */
+/* Resend email — inline text link */
 .blaze-commerce-thank-you-wrapper #resend-email-btn {
-	background: transparent;
-	color: var(--bc-ty-color);
-	border: 1px solid currentColor;
-	border-radius: 9999px;
-	box-shadow: none;
-	text-decoration: none;
+	background: none !important;
+	border: none !important;
+	padding: 0 !important;
+	margin: 0 !important;
+	box-shadow: none !important;
 	font-family: var(--bc-ty-font-family);
-	font-weight: 600;
-	font-size: 16px;
-	line-height: 1.75em;
-	padding: 8px 24px;
-	margin-block-end: var(--theme-content-spacing);
+	font-weight: 400;
+	font-size: inherit;
+	line-height: inherit;
+	color: var(--bc-ty-color);
+	text-decoration: underline !important;
 	cursor: pointer;
-	transition: all 0.2s ease;
-	text-transform: uppercase;
+	display: inline !important;
+	text-transform: none !important;
+	text-align: left !important;
+	vertical-align: baseline;
+	min-height: 0 !important;
+	min-width: 0 !important;
+	width: auto !important;
 }
 
 .blaze-commerce-thank-you-wrapper #resend-email-btn:hover {
-	background: var(--bc-ty-color);
-	color: var(--bc-ty-btn-text);
+	background: none;
+	color: var(--bc-ty-color);
+	opacity: 0.7;
 }
 
 .blaze-commerce-thank-you-wrapper #resend-email-btn:disabled {
-	opacity: 0.6;
+	opacity: 0.5;
 	cursor: not-allowed;
 }
 

--- a/includes/customization/thank-you-page.php
+++ b/includes/customization/thank-you-page.php
@@ -260,12 +260,7 @@ function blocksy_child_blaze_commerce_thank_you_content( $order_id ) {
 							You will receive your confirmation email to <strong><?php echo esc_html( $order->get_billing_email() ); ?></strong> within 5 minutes. If you do not see the email in your inbox, please check your spam or junk folder
 						</p>
 						<div class="resend-email-container">
-							<p>
-								Haven't received the email yet?
-							</p>
-							<button type="button" class="button wp-element-button" id="resend-email-btn" data-order-id="<?php echo esc_attr( $order_id ); ?>" data-order-key="<?php echo esc_attr( $order->get_order_key() ); ?>">
-								Resend Email
-							</button>
+							<p>Haven't received the email yet? <button type="button" class="button wp-element-button" id="resend-email-btn" data-order-id="<?php echo esc_attr( $order_id ); ?>" data-order-key="<?php echo esc_attr( $order->get_order_key() ); ?>">Resend Email</button></p>
 						</div>
 						<div id="resend-feedback" class="resend-feedback" style="display: none;"></div>
 						<p>


### PR DESCRIPTION
## Summary
- Merges "Haven't received the email yet?" text and "Resend Email" button onto one line
- Button styled as inline underlined text link (no border, background, or padding)
- AJAX/JS functionality unaffected — only HTML structure and CSS changed
- Closes CU-86ex8feqm: https://app.clickup.com/t/86ex8feqm

## Test plan
- [ ] Order-received page shows "Haven't received the email yet? Resend Email" on one line
- [ ] "Resend Email" is underlined with no border/background/padding
- [ ] Clicking "Resend Email" triggers AJAX and shows success/error feedback
- [ ] Verified at 320/375/425/768/1024/1440/2560px breakpoints

## Session Resume
```bash
cd /Users/lan/Documents/BLAZE_COMMERCE/delivery/hidden/austin-natural-mattress/86ex8feqm-thank-you-page && claude --resume d0c2ccd4-1d5b-4d9d-aa36-2b568dc4c8d3 --allow-dangerously-skip-permissions --permission-mode plan
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
