### PR TITLE
chore: sync child theme from bbc opti server (v1.1.14 → v1.1.46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,174 @@
+## [woo-cart-smartcoupons-guarded-enqueue-2026-06-03] - 2026-06-03
+
+### Changed
+- Made the Smart Coupons BOGO cart CSS (`woo-cart.css`, migrated earlier today from Blocksy code-snippet #5) load **defensively** instead of unconditionally. Because the rule is client-specific (WebToffee Smart Coupons), `inc/enqueue.php` now gates the `is_cart()` enqueue behind a new `bbc_smart_coupons_cart_css_active()` helper: (1) an on/off switch via the `bbc_smart_coupons_cart_css_enabled` filter (default true — flip to false anywhere to disable site-wide WITHOUT editing the theme); (2) a `class_exists( 'Wt_Smart_Coupon_Giveaway_Product' ) || class_exists( 'Wt_Smart_Coupon' )` guard that covers "plugin not installed right" — deactivated, half-installed, or a renamed build all fall through and the file is never enqueued. The selector remains inert by design (only matches Smart Coupons giveaway markup). WHY: Jayr flagged that a bare always-on CSS hide had no kill-switch and no plugin-present check. Theme 1.1.45 -> 1.1.46.
+
+## [woo-cart-smartcoupons-css-migrate-2026-06-03] - 2026-06-03
+
+### Changed
+- Smart Coupons BOGO giveaway "discount detail" hide on the cart page (`.wt_sc_giveaway_products_cart_page .wt_product_discount { display:none }`) migrated OUT of the Blocksy `code-snippets` extension (snippet #5 "WebToffee Smart Coupons", wp_footer) and INTO the child theme as `assets/css/components/woo-cart.css`, conditionally enqueued on `is_cart()` in `inc/enqueue.php`. WHY: `code-snippets` was dropped from `blocksy_active_extensions` (now 4: woocommerce-extra, mega-menu, local-google-fonts, cookies-consent), which stopped the snippet executing — and the go-live cutover script does not migrate the `unz_snippets` table. Moving the rule into the theme decouples it from the extension and lets the cutover carry it automatically via the theme transfer. Selector only matches when Smart Coupons renders giveaway products, so the rule is inert elsewhere (no PHP guard needed in CSS). Re-added the `is_cart()` enqueue that audit P0.2 (2026-05-07) had removed as dead. Verified RENDERED: `components/woo-cart.css` present in `/cart/` head. Theme 1.1.44 -> 1.1.45.
+
+## [primary-button-hover-letterspacing-2026-06-02] - 2026-06-02
+
+### Fixed
+- #3 primary buttons: RENDERED QA (Browserless computed styles) found Add to Cart + See More were NOT darkening on hover (stayed #DDE2CF) and See More had letter-spacing: normal. Added #3b: hover/focus-visible bg #C5CDB4 + text #3F3A36, and letter-spacing 0.6px across all primary buttons. Theme 1.1.39 -> 1.1.40.
+
+## [mega-menu-columns-padding-2026-06-02] - 2026-06-02
+
+### Fixed
+- ROOT CAUSE of the big gap below mega-menu headings found (Jayr): each column <li> has padding: var(--columns-padding, 20px 30px) = 20px top/bottom per column, which stacked (heading bottom + column top) into a large gap. Reduced --columns-padding vertical 20px -> 8px (kept 30px gutters). Theme 1.1.35 -> 1.1.36.
+
+## [mega-menu-fullwidth-heading-spacing-2026-06-02] - 2026-06-02
+
+### Fixed
+- Diffusers full-width heading (#menu-item-639100 Scented Diffusers, .ct-column-heading): removed leftover Feb padding-bottom:12px on the heading row that made the gap below it too big. Now consistent with uniform item spacing. Theme 1.1.32 -> 1.1.33.
+
+## [mega-menu-heading-balanced-padding-2026-06-02] - 2026-06-02
+
+### Fixed
+- Mega menu heading hover pill was vertically unbalanced (leftover Feb rules: candles padding-bottom 10px + margin-bottom 4px; diffusers padding-bottom 0). Forced headings to Blocksy --menu-item-padding (equal top/bottom, same as items) + margin-bottom 0. Theme 1.1.31 -> 1.1.32.
+
+## [mega-menu-heading-hover-2026-06-02] - 2026-06-02
+
+### Changed
+- Mega menu heading items are clickable category links, so they now get the normal hover pill (#EEF1E5) like any item (client request). Removed the #4b rule that suppressed hover/focus on headings. #4d still forces non-hover/current/focus states transparent, so a heading only highlights when hovered directly (not persistently). Theme 1.1.30 -> 1.1.31.
+
+## [mega-menu-heading-spacing-inherit-2026-06-02] - 2026-06-02
+
+### Fixed
+- Mega menu parent/heading items (e.g. #menu-item-639055 Scented/Citrus Candles) stayed tight because the #4 headings=links block forced padding-bottom:0 + margin-bottom:0, blocking Blocksy item spacing. Removed that zeroing (kept font 500/13px + no divider) so headings inherit the same Blocksy Items Spacing (18px) as every other item. Theme 1.1.29 -> 1.1.30.
+
+## [mega-menu-spacing-customizer-control-2026-06-02] - 2026-06-02
+
+### Changed
+- Mega menu item spacing now fully Customizer-controlled. Removed the last child override (.sub-menu li > a padding 8px 12px) so Blocksy --menu-item-padding (derived from Customizer Items Spacing, dropdownItemsSpacing=13px) governs. For the solid dropdown type Blocksy renders 13px as ~6px vertical padding (calc 13-7). Adjust live via Header > Menu > Dropdown Options > Items Spacing. Theme 1.1.28 -> 1.1.29.
+
+## [mega-menu-item-spacing-blocksy-2026-06-02] - 2026-06-02
+
+### Changed
+- Mega menu item spacing: removed child-theme overrides (.sub-menu li margin 2px + heading row/margin/padding tweaks) that were squashing Blocksy Customizer dropdownItemsSpacing (13px) down to 2px. Spacing is now uniform + Customizer-managed (Header > Menu > Dropdown Options > Items Spacing). Theme 1.1.27 -> 1.1.28.
+
+## [mega-menu-4d-restore-hover-2026-06-02] - 2026-06-02
+
+### Fixed
+- Mega menu: restored the hover tint (#4c :not(:hover) rule had suppressed the visible hover). Now explicit states: base/focus/active/current = transparent (no lingering highlight on headings), :hover/:focus-visible = #EEF1E5. Also halved the full-width column-heading bottom spacing. Theme 1.1.26 -> 1.1.27.
+
+## [mega-menu-4c-only-hover-2026-06-02] - 2026-06-02
+
+### Fixed
+- Mega menu: persistent green on column heading (e.g. Scented Candles) traced to Blocksy (headerDropdownBackground / current-item state), NOT the child theme (verified: no child JS/PHP touches the menu). Added bulletproof rule: .sub-menu li > a:not(:hover):not(:focus-visible) background transparent !important — only the hovered item can ever highlight. Theme 1.1.25 -> 1.1.26.
+
+## [mega-menu-focus-visible-2026-06-02] - 2026-06-02
+
+### Fixed
+- Mega menu: column heading (e.g. Scented Candles) stayed highlighted because the menu-link hover rule also fired on :focus, so the opened/clicked item kept its green tint. Changed :focus -> :focus-visible so a mouse click no longer leaves a lingering highlight (keyboard focus still shows). Now ONLY the hovered item highlights. Theme 1.1.24 -> 1.1.25.
+
+## [mega-menu-4b-heading-spacing-2026-06-02] - 2026-06-02
+
+### Changed
+- Mega menu #4b: +5px breathing room below column headings (was too tight after divider removal); column headings (parent links + .ct-column-heading) no longer highlight on hover/focus so only leaf items highlight (client req). Theme 1.1.23 -> 1.1.24.
+
+## [mega-menu-4-headings-and-font-2026-06-02] - 2026-06-02
+
+### Changed
+- Mega menu (#4): switched header Menu/Dropdown font Museo Sans -> Montserrat (6 theme_mod spots; backup option theme_mods_blocksy_child_bak_2026_06_02). Neutralised the 2026-02-25 column-heading treatment (bold 700, 15px, border-bottom divider) so headings MATCH links (500 / 13px / no divider) per client consistency req. Theme 1.1.22 -> 1.1.23.
+
+## [button-consistency-normalize-2026-06-02] - 2026-06-02
+
+### Changed
+- Normalised secondary buttons to the primary spec for sitewide consistency (weight 500, letter-spacing 0.6px, radius 4px): checkout Place Order/prev/next-step (woo-checkout.css, checkout-step-form.css), variation swatches radius 8->4px (byronbay.css), hero CTA (homepage.css), wishlist signup/continue (wishlist-offcanvas.css), shipping-calc submit (product-information.css). Colours intentionally kept distinct: cookie Decline, coupon-apply outline, FiboSearch View All brown. Theme 1.1.21 -> 1.1.22.
+
+## [primary-button-size-17px-2026-06-02] - 2026-06-02
+
+### Changed
+- Primary button font-size set to 17px (client spec, Launch Checklist \xc2\xa72 Button Typography). Added font-size: 17px !important to both #3 sitewide override groups (.ct-button + anchor/.bc-see-more-link). Theme 1.1.20 -> 1.1.21.
+
+## [bogo-gift-icon-halved-2026-06-01] - 2026-06-01
+
+### Changed
+- BOGO free-gift chooser icon (.wbte_sc_bogo_popup_btn) halved per client request: container 150x150 -> 75x75px, padding 18px -> 9px, inner <img> 96x96 -> 48x48px. Position (fixed bottom-right) untouched. Theme bumped 1.1.19 -> 1.1.20.
+
 # Changelog
 
 All notable changes to the Blocksy child theme. Newest entries first.
+
+## [bogo-popup-cta-buttons-2026-06-01] - 2026-06-01
+
+> **Environment:** bbcv1.blz.au (port 46945). Theme **1.1.18 -> 1.1.19**.
+>
+> **Source:** CU-86extrx5y #3 / #5. Jayr-approved.
+
+### BOGO popup CTA buttons - apply client #3 primary-button spec
+
+The WebToffee Smart Coupons Pro BOGO free-gift popup is body-appended (rendered outside `.woocommerce`), so its two customer CTA buttons fell through the sitewide #3 primary-button override (which is scoped under `.woocommerce`) and rendered with the plugin/theme default `.button` style instead of the client's sage spec. Added a minimal `!important` override targeting only the two front-end CTAs - `.wbte_sc_bogo_add_to_cart` ("Add to cart") and `.wbte_sc_bogo_proceed_checkout` ("Add & go to checkout") - applying the client #3 primary-button spec: background `--theme-palette-color-12 (#DDE2CF)`, hover/focus background `--theme-palette-color-13 (#C5CDB4)`, text + hover text `--theme-palette-color-24 (#3F3A36)`, Montserrat 500, letter-spacing 0.6px, border-radius 4px. Admin/"add new"/dropdown buttons (`wbte_sc_bogo_add_new_*`, `wbte_sc_bogo_edit_*`) intentionally NOT styled. Color/hover/text/font/radius only - no padding/layout change. byronbay.css loads LAST so the override out-specifies the plugin stylesheet. Verified via served-CSS + on-server brace balance; live visual confirm by Jayr (BOGO offer is cart-session-stateful, Playwright resets context here). Theme 1.1.18 -> 1.1.19.
+
+## [qty-stepper-radius-2026-06-01] - 2026-06-01
+
+> **Environment:** bbcv1.blz.au (port 46945). Theme **1.1.17 -> 1.1.18**.
+>
+> **Source:** CU-86extrx5y #3 ("consistent radius sitewide"). Jayr-approved.
+
+### Qty steppers - unify corner radius 8px -> 4px to match primary buttons
+
+The three quantity-stepper blocks (PDP `.ct-cart-actions`, sticky `.ct-floating-bar-actions`, off-canvas `#woo-cart-panel` / `.woocommerce-mini-cart`) used an 8px corner radius on the decrease (top-left + bottom-left) and increase (top-right + bottom-right) buttons. This conflicted with the primary buttons, which honour the Blocksy Customizer `buttonRadius = 4px`. Changed all six `border-*-left-radius`/`border-*-right-radius` declarations from 8px to 4px (6 left + 6 right corner declarations across the 3 blocks) so the steppers match the buttons. The variation-swatch shorthand `border-radius: 8px` on `.ct-swatch` is a separate spec and was intentionally left untouched. Verified via served-CSS + on-server brace balance; zero structural change (byte size unchanged). Theme 1.1.17 -> 1.1.18.
+
+## [bogo-gift-chooser-button-2026-06-01] - 2026-06-01
+
+> **Environment:** bbcv1.blz.au (port 46945). Theme **1.1.16 -> 1.1.17**.
+>
+> **Source:** CU-86extrx5y #5. WebToffee Smart Coupons Pro BOGO free-gift chooser floating button enlarged for discoverability (option A).
+
+### BOGO gift-chooser button - enlarge to 150x150
+
+- **Mechanism:** plugin markup is `<div class='wbte_sc_bogo_popup_btn bottom-right'><img src='bogo_popup_btn.svg'></div>`. The plugin's `modules/bogo/assets/style.css` ships the button at `width:50px; height:50px` (circle) with a 24x24px inner `<img>` glyph.
+- **Fix (byronbay.css, appended last):** high-specificity `!important` block. Container `.wbte_sc_bogo_popup_btn` -> `width/height:150px` + `padding:18px box-sizing:border-box`. Inner `.wbte_sc_bogo_popup_btn img` -> `width/height:96px` (`max-width/height:100%`) so the glyph scales to fill the circle proportionally instead of sitting tiny in a big box. Position (`fixed`, bottom-right) untouched. byronbay.css loads LAST among child CSS so it out-specifies the plugin stylesheet.
+- **Files:** `clients/byronbay/byronbay.css` (+1 block). `style.css` Version 1.1.16 -> 1.1.17.
+- **Verified:** served CSS contains the new selector; braces balanced. BOGO offer is cart-session-stateful (needs 2x "Large - 50 Hour Candles" + `freegift` coupon) and Playwright resets context in this env, so live visual confirmation is by Jayr.
+
+## [minicart-qty-stepper-2026-06-01] - 2026-06-01
+
+> **Environment:** bbcv1.blz.au (port 46945). Theme **1.1.15 -> 1.1.16**.
+>
+> **Source:** CU-86extrx5y. Mini-cart / off-canvas "Your bag" drawer qty stepper restyled to match the PDP + sticky-bar seamless grouped pill, compact for the slim drawer.
+
+### Mini-cart qty stepper - seamless pill (compact)
+
+- **Root cause:** Blocksy's lazy-loaded `cart-header-element-lazy.min.css` loads AFTER `byronbay.css` and `qty-stepper.css`, out-specifying the component knob overrides in `offcanvas.css`. The drawer stepper rendered as three separate boxes: `.ct-decrease`/`.ct-increase` at ~19px (smaller than the 28px input) with per-button 3px radius, not the merged outer-only pill.
+- **Fix (byronbay.css, appended last):** new high-specificity `!important` block scoped to `#woo-cart-panel .ct-product-actions > .quantity[data-type='type-2']` (and the `.woocommerce-mini-cart` fragment variant). Mirrors the existing `.ct-cart-actions` (PDP) and `.ct-floating-bar-actions` (sticky) pill structure: `display:inline-flex`, `position:static`, merged borders (`border-right:0`/`border-left:0`), outer-only 8px radius (decrease order:0 / input order:1 / increase order:2), `1px solid var(--theme-form-field-border-initial-color,#D8D1C7)`, `background:#fff`.
+- **Compact dimensions:** buttons **30px wide x 34px tall**, input **40px wide x 34px tall** (vs PDP 44/46/52, sticky 38/40/46) - smaller to suit the slim drawer.
+- **Files:** `clients/byronbay/byronbay.css` (+1 block). `style.css` Version 1.1.15 -> 1.1.16.
+- **Verified:** served CSS contains the new selector; braces balanced (239/239). Pre-fix broken state confirmed via Playwright computed styles (buttons 19.4px, per-button 3px radius). Stateful Playwright click chains unreliable in this env; relied on served-CSS + computed-style checks.
+
+## [buttons-and-token-refactor-2026-06-01] - 2026-06-01
+
+> **Environment:** bbcv1.blz.au (port 46945). Theme **1.1.14 → 1.1.15**.
+>
+> **Source:** CU-86extrx5y (Anne Marie immediate revisions). Two changes: (1) #3 primary-button spec compliance sitewide; (2) byronbay.css hardcoded-value → design-token refactor (zero visual change).
+
+### #3 — Primary buttons (sitewide)
+
+- **Root cause:** a legacy `font-weight: 600 !important` on `.ct-cart-actions > .single_add_to_cart_button`, plus Blocksy not emitting its `buttonTextColor` theme_mod (buttons rendered `#111` instead of the configured `#3F3A36`).
+- **Fix (byronbay.css):** weight 600 → **500**; added `color: var(--theme-palette-color-24)` (#3F3A36) to the main ATC; appended two sitewide override blocks forcing all primary buttons (ATC main + sticky, cookie Accept/Decline, See More anchors ×9, `.wp-block-button__link`, `.ct-button:not(.ct-button-ghost)`) to button-text color24 + weight 500. Ghost / wishlist / icon buttons untouched.
+- **Spec met:** bg `#DDE2CF` (color12), hover bg `#C5CDB4` (color13), text + hover-text `#3F3A36` (color24), Montserrat 500, letter-spacing 0.6px, border-radius 4px.
+- **Verified:** computed `color: rgb(63, 58, 54)` / `font-weight: 500` on every primary button (main ATC, sticky bar, cookie bar, all 9 See More, block buttons). Uniform.
+
+### Token refactor (byronbay.css, zero visual change)
+
+Every swapped token resolves to the identical current literal — verified before swapping (`--theme-font-family`=Montserrat, palette `color4`=#888888, `--theme-form-field-border-initial-color` fallback=#D8D1C7). No pixel change; maintainability + Customizer-follow only.
+
+- `font-family: Montserrat, sans-serif` → `var(--theme-font-family, Montserrat, sans-serif)` (×2 — variation label, description body). Now follows the Customizer global font.
+- Variation-swatch border `1px solid #D8D1C7` → `1px solid var(--theme-form-field-border-initial-color, #D8D1C7)` (matches the qty-stepper border token).
+- Bare icon grey `#888888` → `var(--theme-palette-color-4, #888888)` (×6; matches the 3 pre-existing var-wrapped usages — color4 IS #888888).
+- Hover tints `#E6EAD9` (swatch) + `#EEF1E5` (mega-menu) → new `:root` design tokens `--bc-swatch-hover-bg` / `--bc-menu-hover-bg` (single source of truth).
+
+### Deliberate scope decisions
+
+- **Museo Sans fallback retained** — it's a child-theme-wide convention across 5+ component CSS files (header, checkout-*, search-dropdown); removing it from byronbay.css alone would create drift. No `@font-face`/`@import` in this file (matches the live site's Adobe Fonts).
+- **`#fff` literals (×6) left as-is** — white qty/swatch backgrounds aren't a theming concern.
+- **Qty-stepper DRY merge deferred** — the `.ct-cart-actions` (46px) and `.ct-floating-bar-actions` (40px) blocks are *not* duplicates (different dimensions) and are Playwright-verified working. Merging risks regressing a working component for marginal gain; tracked as a separate task.
+
+Files: `clients/byronbay/byronbay.css`. In-place backup: `byronbay.css.bak-2026-06-01`.
+
 ## [anne-marie-kickback-2026-05-13] - 2026-05-13
 
 > **Environment:** bbcv1.blz.au (port 46945, ex-FROZEN, now opened back up after the 2026-05-13 STG→bbcv1 restore). Theme **1.1.13 → 1.1.14**.

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -128,7 +128,7 @@ h3.bc-decorated-heading::after {
    @since 1.0.0
    ========================================================================== */
 .bc-visual-h2 {
-	font-family: Quicksand, sans-serif;
+	font-family: var(--theme-font-family, Montserrat), sans-serif;
 	font-size: 36px !important;
 	font-weight: 600 !important;
 	line-height: 1.2;
@@ -199,4 +199,10 @@ body.page-id-645912 {
 	--global-palette26: var(--theme-palette-color-26, #F7FBFC);
 	--global-palette27: var(--theme-palette-color-27, #2890a8);
 	--global-palette28: var(--theme-palette-color-28, #C1B19E);
+}
+
+/* Global button font-weight + text colour (migrated 2026-06-04 from Customizer Additional CSS). */
+.button, .ct-button, .added_to_cart, .ct-button-ghost, [type=submit], .wp-element-button, .wp-block-button__link, button.regform-button, button[class*=ajax], .woocommerce button.button, .woocommerce-message .showlogin, .woocommerce-message .restore-item, .forminator-ui[data-design=none] .forminator-button, .fluentform .ff-el-group button.ff-btn, .ct-button-secondary-text {
+	--theme-button-font-weight: 500;
+	--theme-button-text-initial-color: #111111;
 }

--- a/assets/css/components/checkout-order-summary.css
+++ b/assets/css/components/checkout-order-summary.css
@@ -8,20 +8,20 @@
  *
  * Figma spec:
  *   Card: bg #fff, border 1px #cfcfcf, radius 12px, padding 24px
- *   Title: Quicksand 400 24px var(--fc-text-strong, #393939)
- *   Badge: Quicksand 700 12px, pill (9999px), border 1px #cfcfcf
- *   Product name: Quicksand 500 18px var(--fc-text-brown, #746a5f)
- *   Price note: Quicksand 400 14px var(--fc-text-soft, #888888)
+ *   Title: var(--theme-font-family, Montserrat) 400 24px var(--fc-text-strong, #393939)
+ *   Badge: var(--theme-font-family, Montserrat) 700 12px, pill (9999px), border 1px #cfcfcf
+ *   Product name: var(--theme-font-family, Montserrat) 500 18px var(--fc-text-brown, #746a5f)
+ *   Price note: var(--theme-font-family, Montserrat) 400 14px var(--fc-text-soft, #888888)
  *   Remove: trash icon 20x20 var(--fc-text-brown, #746a5f)
  *   Thumbnail: 120x120, container 6px radius, image 8px radius
- *   Coupon toggle: Quicksand 400 18px var(--fc-text-strong, #393939)
+ *   Coupon toggle: var(--theme-font-family, Montserrat) 400 18px var(--fc-text-strong, #393939)
  *   Coupon input: 8px radius, border #dddddd
- *   Apply btn: bordered, Museo Sans 700 16px, border 1px #353638, radius 8px
- *   Totals rows: Quicksand 400 18px var(--fc-text-strong, #393939)
- *   Total amount: Quicksand 700 24px var(--fc-text-strong, #393939)
- *   Shipping note: Museo Sans 400 14px #030712
+ *   Apply btn: bordered, var(--theme-font-family, Montserrat) 700 16px, border 1px #353638, radius 8px
+ *   Totals rows: var(--theme-font-family, Montserrat) 400 18px var(--fc-text-strong, #393939)
+ *   Total amount: var(--theme-font-family, Montserrat) 700 24px var(--fc-text-strong, #393939)
+ *   Shipping note: var(--theme-font-family, Montserrat) 400 14px #030712
  *   Shipping bar: track #dddddd 6px, fill #163317
- *   Qty selector: 6px radius, border 1px #cfcfcf, Quicksand 400 18px
+ *   Qty selector: 6px radius, border 1px #cfcfcf, var(--theme-font-family, Montserrat) 400 18px
  */
 
 /* =============================================
@@ -100,10 +100,10 @@ html body.woocommerce-checkout #fc-checkout-order-review {
 		margin: 0 !important;
 	}
 
-	/* Title — Quicksand 400 24px var(--fc-text-strong, #393939) */
+	/* Title — var(--theme-font-family, Montserrat) 400 24px var(--fc-text-strong, #393939) */
 	body.woocommerce-checkout div.woocommerce .fc-wrapper .fc-checkout-order-review-title,
 	body.woocommerce-checkout div.woocommerce .fc-wrapper .fc-checkout-order-review__title {
-		font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+		font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 		font-size: 24px !important;
 		font-weight: 400 !important;
 		line-height: 28px !important;
@@ -168,7 +168,7 @@ a.fc-checkout-order-review__edit-cart {
 }
 
 /* =============================================
-   ITEM COUNT BADGE — Quicksand 700 12px, pill shape
+   ITEM COUNT BADGE — var(--theme-font-family, Montserrat) 700 12px, pill shape
 ============================================= */
 .bc-os-item-count {
 	display: inline-flex;
@@ -179,7 +179,7 @@ a.fc-checkout-order-review__edit-cart {
 	border: 1px solid var(--bc-os-card-border);
 	color: var(--bc-os-title-color);
 	border-radius: 9999px;
-	font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif);
+	font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif);
 	font-size: 14px;
 	font-weight: 700;
 	line-height: 16px;
@@ -190,14 +190,14 @@ a.fc-checkout-order-review__edit-cart {
    PRODUCT TYPOGRAPHY — DESKTOP DEFAULTS
 ============================================= */
 
-/* Product name: Quicksand 500 18px var(--fc-text-brown, #746a5f) */
+/* Product name: var(--theme-font-family, Montserrat) 500 18px var(--fc-text-brown, #746a5f) */
 .fc-checkout-order-review .product-name,
 .fc-checkout-order-review .cart-item__name,
 .fc-checkout-order-review td.product-name a,
 .fc-checkout-order-review .cart_item .product-name a,
 body.woocommerce-checkout .woocommerce-checkout-review-order-table .product-name .cart-item__name,
 body.woocommerce-checkout .woocommerce-checkout-review-order-table .product-name .product-details > a {
-	font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+	font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 	font-size: 18px !important;
 	font-weight: 500 !important;
 	line-height: 24px !important;
@@ -211,14 +211,14 @@ body.woocommerce-checkout .woocommerce-checkout-review-order-table .product-name
 	display: block;
 }
 
-/* Variant/meta: Quicksand 400 16px var(--fc-text-brown, #746a5f) */
+/* Variant/meta: var(--theme-font-family, Montserrat) 400 16px var(--fc-text-brown, #746a5f) */
 .fc-checkout-order-review .variation,
 .fc-checkout-order-review .product-name .variation dd,
 .fc-checkout-order-review .product-name .variation dt,
 .fc-checkout-order-review dl.variation,
 .fc-checkout-order-review .cart-item__name dl.variation,
 .fc-checkout-order-review .cart-item__name dl.variation dd {
-	font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+	font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 	font-size: 16px !important;
 	font-weight: 400 !important;
 	line-height: 24px !important;
@@ -270,7 +270,7 @@ div.woocommerce .fc-wrapper #order_review table.woocommerce-checkout-review-orde
 	display: block !important;
 	margin: 4px 0 8px 0 !important;
 	text-align: left !important;
-	font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+	font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 	font-size: 14px !important;
 	line-height: 20px !important;
 	color: var(--bc-os-title-color) !important;
@@ -279,7 +279,7 @@ div.woocommerce .fc-wrapper #order_review table.woocommerce-checkout-review-orde
 /* Non-sale price: regular weight, dark */
 .fc-checkout-order-review .cart-item__price > .woocommerce-Price-amount,
 .fc-checkout-order-review .cart-item__price > .amount {
-	font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+	font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 	font-size: 14px !important;
 	font-weight: 400 !important;
 	color: var(--bc-os-title-color) !important;
@@ -308,7 +308,7 @@ div.woocommerce .fc-wrapper #order_review table.woocommerce-checkout-review-orde
 /* GST note: 14px var(--fc-text-soft, #888888) */
 .fc-checkout-order-review .cart-item__price .includes_tax,
 .fc-checkout-order-review .cart-item__price small.tax_label {
-	font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+	font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 	font-size: 14px !important;
 	font-weight: 400 !important;
 	line-height: 20px !important;
@@ -362,7 +362,7 @@ div.woocommerce .fc-wrapper .cart-item a.remove svg {
    @date 2026-04-23 */
 html body .fc-wrapper .number-spin-button {
 	border-radius: 0 !important;
-	font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+	font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 	border: 1px solid var(--bc-os-card-border) !important;
 	background: var(--bc-os-card-bg) !important;
 	width: 32px !important;
@@ -384,7 +384,7 @@ html body .fc-wrapper .number-spin-button.plus {
 }
 /* Qty input between buttons — Figma: px-16 py-8 */
 html body .fc-wrapper .quantity input.qty {
-	font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+	font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 	font-size: 18px !important;
 	font-weight: 400 !important;
 	line-height: 24px !important;
@@ -461,11 +461,11 @@ html body .fc-checkout-order-review .woocommerce-checkout-review-order-table tfo
 		justify-content: space-between;
 	}
 
-	/* Toggle title — Quicksand 400 14px var(--fc-text-strong, #393939) */
+	/* Toggle title — var(--theme-font-family, Montserrat) 400 14px var(--fc-text-strong, #393939) */
 	.fc-wrapper .fc-checkout-order-review-collapsible__title,
 	body.woocommerce-checkout .fc-checkout-order-review-collapsible__title,
 	body.woocommerce-checkout .fc-checkout-order-review-collapsible .fc-checkout-order-review-collapsible__title {
-		font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+		font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 		font-size: 14px !important;
 		font-weight: 400 !important;
 		line-height: 1.5 !important;
@@ -477,7 +477,7 @@ html body .fc-checkout-order-review .woocommerce-checkout-review-order-table tfo
 
 	/* Toggle total */
 	.fc-checkout-order-review-collapsible__total {
-		font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+		font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 		font-weight: 500 !important;
 		color: var(--bc-os-title-color) !important;
 	}
@@ -494,7 +494,7 @@ html body .fc-checkout-order-review .woocommerce-checkout-review-order-table tfo
 	h3.bc-mobile-order-summary-heading,
 	body.woocommerce-checkout h3.bc-mobile-order-summary-heading {
 		display: block !important;
-		font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+		font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 		font-size: 20px !important;
 		font-weight: 400 !important;
 		color: var(--bc-os-title-color) !important;
@@ -780,13 +780,13 @@ html body .fc-checkout-order-review .woocommerce-checkout-review-order-table tfo
 }
 
 /* =============================================
-   TOTALS TABLE — Desktop defaults: Quicksand 18px var(--fc-text-strong, #393939)
+   TOTALS TABLE — Desktop defaults: var(--theme-font-family, Montserrat) 18px var(--fc-text-strong, #393939)
    Labels (th): 400 weight. Values (td): 400 weight. Total: 700 weight.
    ID-based selectors to beat FC Pro.
 ============================================= */
 html body div.woocommerce .fc-wrapper #order_review table.woocommerce-checkout-review-order-table tfoot tr th,
 html body div.woocommerce .fc-wrapper .fc-review-order-totals-table tfoot tr th {
-	font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+	font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 	font-size: 18px !important;
 	font-weight: 400 !important;
 	color: var(--bc-os-title-color) !important;
@@ -795,7 +795,7 @@ html body div.woocommerce .fc-wrapper #order_review table.woocommerce-checkout-r
 html body div.woocommerce .fc-wrapper #order_review table.woocommerce-checkout-review-order-table tfoot tr td .amount,
 html body div.woocommerce .fc-wrapper .fc-review-order-totals-table tfoot tr td,
 html body div.woocommerce .fc-wrapper .fc-review-order-totals-table tfoot tr td .amount {
-	font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+	font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 	font-size: 18px !important;
 	font-weight: 400 !important;
 	color: var(--bc-os-title-color) !important;
@@ -827,19 +827,19 @@ html body div.woocommerce .fc-wrapper .fc-review-order-totals-table tfoot tr.ord
 }
 
 /* =============================================
-   TOTAL AMOUNT — Desktop: Quicksand 700 24px var(--fc-text-strong, #393939)
+   TOTAL AMOUNT — Desktop: var(--theme-font-family, Montserrat) 700 24px var(--fc-text-strong, #393939)
 ============================================= */
 html body div.woocommerce .fc-wrapper #order_review table.woocommerce-checkout-review-order-table tfoot tr.order-total td .amount,
 html body div.woocommerce .fc-wrapper #order_review table.woocommerce-checkout-review-order-table tfoot tr.order-total td .woocommerce-Price-amount,
 html body div.woocommerce .fc-wrapper .fc-review-order-totals-table tfoot tr.order-total td .amount {
-	font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+	font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 	font-size: 24px !important;
 	font-weight: 700 !important;
 	line-height: 28px !important;
 	color: var(--bc-os-total-color) !important;
 }
 
-/* Mobile total: Quicksand 700 20px */
+/* Mobile total: var(--theme-font-family, Montserrat) 700 20px */
 @media (max-width: 767px) {
 	html body div.woocommerce .fc-wrapper #order_review table.woocommerce-checkout-review-order-table tfoot tr.order-total td .amount,
 	html body div.woocommerce .fc-wrapper #order_review table.woocommerce-checkout-review-order-table tfoot tr.order-total td .woocommerce-Price-amount,
@@ -849,7 +849,7 @@ html body div.woocommerce .fc-wrapper .fc-review-order-totals-table tfoot tr.ord
 	}
 }
 
-/* Tablet total: Quicksand 700 22px */
+/* Tablet total: var(--theme-font-family, Montserrat) 700 22px */
 @media (min-width: 768px) and (max-width: 999px) {
 	html body div.woocommerce .fc-wrapper #order_review table.woocommerce-checkout-review-order-table tfoot tr.order-total td .amount,
 	html body div.woocommerce .fc-wrapper #order_review table.woocommerce-checkout-review-order-table tfoot tr.order-total td .woocommerce-Price-amount,
@@ -866,12 +866,12 @@ html body div.woocommerce .fc-wrapper .fc-review-order-totals-table tfoot tr.ord
 }
 
 /* =============================================
-   SHIPPING NOTE — Museo Sans 400 14px #030712
+   SHIPPING NOTE — var(--theme-font-family, Montserrat) 400 14px #030712
 ============================================= */
 .fc-checkout-order-review .woocommerce-shipping-destination,
 .fc-checkout-order-review .shipping-note,
 .woocommerce-checkout-review-order-table tfoot .woocommerce-shipping-destination {
-	font-family: var(--bc-sf-font-label, 'Museo Sans', var(--theme-body-font-family, sans-serif)) !important;
+	font-family: var(--bc-sf-font-label, var(--theme-font-family, Montserrat), var(--theme-body-font-family, sans-serif)) !important;
 	font-size: 14px !important;
 	font-weight: 400 !important;
 	line-height: 20px !important;
@@ -1043,7 +1043,7 @@ div.woocommerce .fc-wrapper .fc-review-order-totals-table tfoot tr.coupon-code-f
 	content: none !important;
 }
 
-/* Toggle link — Quicksand 400 18px var(--fc-text-strong, #393939) */
+/* Toggle link — var(--theme-font-family, Montserrat) 400 18px var(--fc-text-strong, #393939) */
 html body div.woocommerce .fc-wrapper #order_review .fc-coupon_code__collapsible .expansible-section__toggle-plus,
 .fc-coupon_code__collapsible .expansible-section__toggle-plus {
 	display: flex !important;
@@ -1051,7 +1051,7 @@ html body div.woocommerce .fc-wrapper #order_review .fc-coupon_code__collapsible
 	justify-content: space-between !important;
 	width: 100% !important;
 	padding: 8px 0 !important;
-	font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+	font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 	font-size: 18px !important;
 	font-weight: 400 !important;
 	color: var(--bc-os-title-color) !important;
@@ -1142,7 +1142,7 @@ html body .fc-coupon_code__collapsible .fc-expansible-form-section__toggle .coll
 }
 .fc-coupon-code-section input[type="text"] {
 	width: 100% !important;
-	font-family: var(--bc-sf-font-label, 'Museo Sans', var(--theme-body-font-family, sans-serif)) !important;
+	font-family: var(--bc-sf-font-label, var(--theme-font-family, Montserrat), var(--theme-body-font-family, sans-serif)) !important;
 	font-size: 14px !important;
 	font-weight: 400 !important;
 	color: var(--bc-os-title-color) !important;
@@ -1158,12 +1158,12 @@ html body .fc-coupon_code__collapsible .fc-expansible-form-section__toggle .coll
 	opacity: 0.5;
 }
 
-/* Apply button — bordered, Museo Sans 700 16px, border 1px #353638, radius 8px */
+/* Apply button — bordered, var(--theme-font-family, Montserrat) 700 16px, border 1px #353638, radius 8px */
 body div.woocommerce .woocommerce-checkout .fc-coupon-code-section .fc-coupon-code__apply,
 body div.woocommerce .woocommerce-checkout .fc-coupon-code-section button[data-apply-coupon-button] {
 	position: static !important;
 	top: auto !important;
-	font-family: var(--bc-sf-font-label, 'Museo Sans', var(--theme-body-font-family, sans-serif)) !important;
+	font-family: var(--bc-sf-font-label, var(--theme-font-family, Montserrat), var(--theme-body-font-family, sans-serif)) !important;
 	font-size: 16px !important;
 	font-weight: 700 !important;
 	color: var(--bc-os-coupon-btn-text) !important;
@@ -1205,12 +1205,12 @@ body div.woocommerce .woocommerce-checkout .fc-coupon-code-section button[data-a
 }
 
 /* =============================================
-   TABLET TITLE (768-999px): Quicksand 400 24px
+   TABLET TITLE (768-999px): var(--theme-font-family, Montserrat) 400 24px
 ============================================= */
 @media (min-width: 768px) and (max-width: 999px) {
 	body.woocommerce-checkout .fc-checkout-order-review-title,
 	body.woocommerce-checkout .fc-checkout-order-review__title {
-		font-family: var(--bc-sf-font-body, 'Quicksand', sans-serif) !important;
+		font-family: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif) !important;
 		font-size: 24px !important;
 		font-weight: 400 !important;
 		color: var(--bc-os-title-color) !important;

--- a/assets/css/components/checkout-step-form.css
+++ b/assets/css/components/checkout-step-form.css
@@ -8,12 +8,12 @@
  *
  * Figma spec:
  *   Step card: border 1px #CFCFCF, radius 12px, overflow hidden
- *   Substep title: Quicksand 400 18px var(--fc-text-strong, #393939), uppercase, checkmark icon
+ *   Substep title: var(--theme-font-family, Montserrat) 400 18px var(--fc-text-strong, #393939), uppercase, checkmark icon
  *   Login banner: bg var(--fc-bg-pale, #F7FBFC), centered, "Log in" bold 700 underlined
- *   Guest divider: line #E4E5E7, text Quicksand 300 14px var(--fc-text-soft, #888)
- *   Form labels: Museo Sans 500 18px #111, asterisk var(--fc-error, #EF4444)
+ *   Guest divider: line #E4E5E7, text var(--theme-font-family, Montserrat) 300 14px var(--fc-text-soft, #888)
+ *   Form labels: var(--theme-font-family, Montserrat) 500 18px #111, asterisk var(--fc-error, #EF4444)
  *   Inputs: h48px, p-12, radius 8px, border 1px #CFCFCF
- *   CTA button: bg #D9EAF0, Quicksand 400 18px #111, radius 4px, arrow
+ *   CTA button: bg #D9EAF0, var(--theme-font-family, Montserrat) 400 18px #111, radius 4px, arrow
  *
  * @package Blocksy_Child
  * @date    2026-04-23
@@ -35,8 +35,8 @@ body.woocommerce-checkout {
 	--bc-sf-login-bg: var(--fc-bg-pale, #F7FBFC);
 	--bc-sf-asterisk-color: var(--fc-error, #EF4444);
 	--bc-sf-btn-shadow: 0px 1px 2px rgba(0, 0, 0, 0.12);
-	--bc-sf-font-body: var(--bc-sf-font-body, 'Quicksand', sans-serif);
-	--bc-sf-font-label: var(--bc-sf-font-label, 'Museo Sans', var(--theme-body-font-family, sans-serif));
+	--bc-sf-font-body: var(--bc-sf-font-body, var(--theme-font-family, Montserrat), sans-serif);
+	--bc-sf-font-label: var(--bc-sf-font-label, var(--theme-font-family, Montserrat), var(--theme-body-font-family, sans-serif));
 }
 
 /* =============================================
@@ -57,12 +57,12 @@ body.woocommerce-checkout {
 
 /* =============================================
    3. SUBSTEP TITLE ("ACCOUNT")
-   Figma: checkmark icon 24x24 + "ACCOUNT" Quicksand 400 18px var(--fc-text-strong, #393939)
+   Figma: checkmark icon 24x24 + "ACCOUNT" var(--theme-font-family, Montserrat) 400 18px var(--fc-text-strong, #393939)
    Padding: pt-16 px-16, gap 8px between icon and text
 ============================================= */
 body.woocommerce-checkout div.woocommerce .fc-wrapper .fc-step__substep .fc-step__substep-title {
 	font-family: var(--bc-sf-font-body) !important;
-	font-weight: 400 !important;
+	font-weight: 500 !important;
 	font-size: 18px !important;
 	line-height: 24px !important;
 	color: var(--bc-sf-text-primary) !important;
@@ -114,8 +114,8 @@ body.woocommerce-checkout .fc-wrapper .fc-step__substep-title--contact {
 /* =============================================
    4. LOGIN BANNER
    Figma: bg var(--fc-bg-pale, #F7FBFC), py-16, centered
-   "Already have an account?" Quicksand 400 18px var(--fc-text-strong, #393939)
-   "Log in" Quicksand 700 18px var(--fc-text-strong, #393939), underlined
+   "Already have an account?" var(--theme-font-family, Montserrat) 400 18px var(--fc-text-strong, #393939)
+   "Log in" var(--theme-font-family, Montserrat) 700 18px var(--fc-text-strong, #393939), underlined
 ============================================= */
 body.woocommerce-checkout .fc-wrapper .fc-contact-login__content {
 	background-color: var(--bc-sf-login-bg) !important;
@@ -146,7 +146,7 @@ body.woocommerce-checkout .fc-wrapper .fc-contact-login__action {
 
 /* =============================================
    5. GUEST DIVIDER
-   Figma: line #E4E5E7 — "Or continue as a guest" Quicksand 300 14px var(--fc-text-soft, #888) — line
+   Figma: line #E4E5E7 — "Or continue as a guest" var(--theme-font-family, Montserrat) 300 14px var(--fc-text-soft, #888) — line
 ============================================= */
 body.woocommerce-checkout .fc-wrapper .fc-contact-login__separator {
 	margin-bottom: 16px !important;
@@ -169,8 +169,8 @@ body.woocommerce-checkout .fc-wrapper .fc-contact-login__separator-text {
 
 /* =============================================
    6. GUEST DESCRIPTION TEXT
-   Figma Desktop: Quicksand 400 18px var(--fc-text-strong, #393939)
-   Figma Mobile: Quicksand 300 14px var(--fc-text-strong, #393939)
+   Figma Desktop: var(--theme-font-family, Montserrat) 400 18px var(--fc-text-strong, #393939)
+   Figma Mobile: var(--theme-font-family, Montserrat) 300 14px var(--fc-text-strong, #393939)
    Injected via PHP hook: fc_checkout_before_contact_fields
 ============================================= */
 .bc-guest-description {
@@ -185,7 +185,7 @@ body.woocommerce-checkout .fc-wrapper .fc-contact-login__separator-text {
 
 /* =============================================
    7. FORM LABELS
-   Figma: Museo Sans 500 18px #111, asterisk var(--fc-error, #EF4444)
+   Figma: var(--theme-font-family, Montserrat) 500 18px #111, asterisk var(--fc-error, #EF4444)
 ============================================= */
 body.woocommerce-checkout .fc-wrapper .form-row > label,
 body.woocommerce-checkout div.woocommerce .fc-wrapper .form-row > label {
@@ -216,7 +216,7 @@ body.woocommerce-checkout .fc-wrapper .form-row > label .optional {
 /* =============================================
    8. INPUT FIELDS
    Figma: h48px, p-12, radius 8px, border 1px #CFCFCF
-   Placeholder: Quicksand 300 14px var(--fc-text-soft, #888)
+   Placeholder: var(--theme-font-family, Montserrat) 300 14px var(--fc-text-soft, #888)
 ============================================= */
 body.woocommerce-checkout {
 	--fluidcheckout--field--height: var(--bc-sf-input-height);
@@ -283,7 +283,7 @@ body.woocommerce-checkout .fc-wrapper .select2-container .select2-selection--sin
 
 /* =============================================
    9. HELPER / DESCRIPTION TEXT
-   Figma: Quicksand 300 14px var(--fc-text-strong, #393939) below inputs
+   Figma: var(--theme-font-family, Montserrat) 300 14px var(--fc-text-strong, #393939) below inputs
    e.g. "Order number and receipt will be sent to this email address"
 ============================================= */
 body.woocommerce-checkout .fc-wrapper .form-row .description,
@@ -301,7 +301,7 @@ body.woocommerce-checkout .fc-wrapper .form-row .woocommerce-input-wrapper + .de
 /* =============================================
    10. CHECKBOX STYLING
    Figma: 16x16, radius 4px, border 1px #CFCFCF
-   Label: Quicksand 400 14px var(--fc-text-soft, #888)
+   Label: var(--theme-font-family, Montserrat) 400 14px var(--fc-text-soft, #888)
 ============================================= */
 body.woocommerce-checkout .fc-wrapper input[type="checkbox"] {
 	width: 16px !important;
@@ -355,7 +355,7 @@ body.woocommerce-checkout .fc-wrapper .form-row.create-account label {
 /* =============================================
    11. CTA BUTTON (NEXT STEP)
    Figma: bg #D9EAF0 (already via --fc-btn-primary-bg in byronbay.css)
-   Quicksand 400 18px #111, p-16, radius 4px
+   var(--theme-font-family, Montserrat) 400 18px #111, p-16, radius 4px
    Shadow: 0px 1px 2px rgba(0,0,0,0.12), arrow icon
 ============================================= */
 
@@ -369,11 +369,11 @@ body.woocommerce-checkout .has-checkout-layout--multi-step .fc-step__actions .fc
 body.woocommerce-checkout .fc-step__actions .button,
 body.woocommerce-checkout .fc-step__actions .fc-step__next-btn {
 	font-family: var(--bc-sf-font-body) !important;
-	font-weight: 400 !important;
+	font-weight: 500 !important;
 	font-size: 18px !important;
 	line-height: 24px !important;
 	text-transform: uppercase !important;
-	letter-spacing: 0 !important;
+	letter-spacing: 0.6px !important;
 	padding: 16px !important;
 	border-radius: 4px !important;
 	box-shadow: var(--bc-sf-btn-shadow) !important;

--- a/assets/css/components/checkout-trust-badges.css
+++ b/assets/css/components/checkout-trust-badges.css
@@ -77,7 +77,7 @@
 }
 
 .bc-checkout-trust__heading {
-	font-family: var(--bc-sf-font-label, 'Museo Sans', var(--theme-body-font-family, sans-serif));
+	font-family: var(--bc-sf-font-label, var(--theme-font-family, Montserrat), var(--theme-body-font-family, sans-serif));
 	font-size: 14px;
 	font-weight: 700;
 	line-height: 26px;
@@ -86,7 +86,7 @@
 }
 
 .bc-checkout-trust__body {
-	font-family: var(--bc-sf-font-label, 'Museo Sans', var(--theme-body-font-family, sans-serif));
+	font-family: var(--bc-sf-font-label, var(--theme-font-family, Montserrat), var(--theme-body-font-family, sans-serif));
 	font-size: 14px;
 	font-weight: 400;
 	line-height: 26px;

--- a/assets/css/components/header.css
+++ b/assets/css/components/header.css
@@ -41,7 +41,7 @@
 	border-radius: 8px;
 	border: 1px solid var(--theme-palette-color-16, #CFCFCF);
 	background: var(--theme-palette-color-17, #FFFFFF);
-	font-family: 'Museo Sans', sans-serif;
+	font-family: var(--theme-font-family, Montserrat), sans-serif;
 	font-size: 14px;
 	color: var(--theme-palette-color-3, #746A5F);
 	padding: 0 48px 0 16px;
@@ -343,14 +343,14 @@ body.woocommerce-cart .ct-contact-info .ct-icon-container svg path {
   fill: none !important;
 }
 
-/* Phone number typography — Figma node 6117-158097: Quicksand 16px w=400 #111111.
+/* Phone number typography — Figma node 6117-158097: var(--theme-font-family, Montserrat) 16px w=400 #111111.
    Blocksy Customizer contacts block inherits Rubik 500 from the body font
    assignment; override here to match Figma. */
 body.woocommerce-checkout .ct-contact-info .contact-text,
 body.woocommerce-checkout .ct-contact-info .contact-text a,
 body.woocommerce-cart .ct-contact-info .contact-text,
 body.woocommerce-cart .ct-contact-info .contact-text a {
-  font-family: Quicksand, sans-serif !important;
+  font-family: var(--theme-font-family, Montserrat), sans-serif !important;
   font-weight: 400 !important;
   font-size: 16px !important;
   color: #111111 !important;

--- a/assets/css/components/homepage.css
+++ b/assets/css/components/homepage.css
@@ -98,7 +98,7 @@ body.page-id-645912 .site-main {
 }
 
 .bc-hero-slide-content h2 {
-	font-family: var(--theme-headings-font-family, Quicksand, sans-serif);
+	font-family: var(--theme-headings-font-family, var(--theme-font-family, Montserrat), sans-serif);
 	font-size: 56px;
 	font-weight: 500;
 	line-height: 1.1;
@@ -122,12 +122,12 @@ body.page-id-645912 .site-main {
 	padding: 14px 32px;
 	background: var(--theme-button-background-initial-color, transparent);
 	color: var(--theme-button-text-initial-color, #111);
-	border-radius: var(--theme-button-border-radius, 8px);
+	border-radius: var(--theme-button-border-radius, 4px);
 	font-size: 14px;
-	font-weight: 600;
+	font-weight: 500;
 	text-decoration: none;
 	text-transform: uppercase;
-	letter-spacing: 0.05em;
+	letter-spacing: 0.6px;
 	transition: background 0.2s;
 }
 

--- a/assets/css/components/offcanvas.css
+++ b/assets/css/components/offcanvas.css
@@ -56,7 +56,7 @@
    ========================================================================== */
 
 /* Drawer heading typography — matches Figma node 16:140 H5 spec exactly:
-   Quicksand Regular 400 / 24px / 28px / #111. Weight, line-height and color
+   var(--theme-font-family, Montserrat) Regular 400 / 24px / 28px / #111. Weight, line-height and color
    are explicitly set (not via theme vars) so the Customizer's heading-2
    tokens don't override these drawer-specific values. CU-86exbe71m. */
 #woo-cart-panel .ct-panel-heading,
@@ -64,7 +64,7 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	font-family: 'Quicksand', var(--theme-heading-2-font-family, var(--theme-headings-font-family, sans-serif));
+	font-family: var(--theme-font-family, Montserrat), var(--theme-heading-2-font-family, var(--theme-headings-font-family, sans-serif));
 	font-size: 24px;
 	font-weight: 400;
 	line-height: 28px;
@@ -458,7 +458,7 @@
    on qty change because cart-fragments AJAX re-renders the whole
    widget_shopping_cart_content subtree.
 
-   Layout (Figma 684:85959 typography tokens — Quicksand):
+   Layout (Figma 684:85959 typography tokens — var(--theme-font-family, Montserrat)):
      - Shipping row (when cart needs shipping): label + "Calculated at
        checkout", 14px, secondary text color
      - Order Total row: label + amount, 16px, semibold, divider above
@@ -638,4 +638,27 @@
 #woo-cart-panel .woocommerce-mini-cart.product_list_widget li,
 .woocommerce-mini-cart.product_list_widget li {
 	align-items: start;
+}
+
+
+/* == Mini-cart text weight -> 400 (Annemarie request, 2026-06-09) =========
+   Regular-weight text in the 'Your bag' drawer. Overrides component design
+   weights to 400: product title/price (was 500), SUBTOTAL (Blocksy 700),
+   Order Total + value (was 600), AND the free-shipping bar message
+   (Blocksy 300 -> 400, for a uniform drawer; the Customizer message field has
+   no font-weight control). Scoped to #woo-cart-panel + the .woocommerce-mini-cart
+   fragment. Delete this block to restore design weights. */
+#woo-cart-panel .bc-mini-product-title,
+#woo-cart-panel .bc-mini-product-price,
+#woo-cart-panel .woocommerce-mini-cart__total,
+#woo-cart-panel .bc-mini-cart-totals__total,
+#woo-cart-panel .bc-mini-cart-totals__total .bc-mini-cart-totals__value,
+#woo-cart-panel .ct-shipping-progress-mini-cart .ct-message,
+#woo-cart-panel .ct-shipping-progress-mini-cart .ct-message p,
+.woocommerce-mini-cart .bc-mini-product-title,
+.woocommerce-mini-cart .bc-mini-product-price,
+.woocommerce-mini-cart .woocommerce-mini-cart__total,
+.woocommerce-mini-cart .ct-shipping-progress-mini-cart .ct-message,
+.woocommerce-mini-cart .ct-shipping-progress-mini-cart .ct-message p {
+	font-weight: 400 !important;
 }

--- a/assets/css/components/product-information.css
+++ b/assets/css/components/product-information.css
@@ -229,15 +229,15 @@
 	width: 100%;
 	padding: 14px 24px;
 	border: none;
-	border-radius: var(--theme-button-border-radius, 8px);
+	border-radius: var(--theme-button-border-radius, 4px);
 	background: var(--theme-button-background-initial-color, var(--theme-palette-color-12, transparent));
 	color: var(--theme-button-text-initial-color, var(--theme-palette-color-1, #111));
 	font-size: 14px;
-	font-weight: 600;
+	font-weight: 500;
 	cursor: pointer;
 	transition: background 0.2s, color 0.2s;
 	text-transform: uppercase;
-	letter-spacing: 0.5px;
+	letter-spacing: 0.6px;
 	box-sizing: border-box;
 }
 

--- a/assets/css/components/search-dropdown.css
+++ b/assets/css/components/search-dropdown.css
@@ -177,7 +177,7 @@ body .dgwt-wcas-suggestions-wrapp .dgwt-wcas-section-products {
    ========================================================================== */
 
 body .dgwt-wcas-suggestions-wrapp .dgwt-wcas-section-title {
-    font-family: 'Museo Sans', var(--theme-body-font-family, sans-serif);
+    font-family: var(--theme-font-family, Montserrat), var(--theme-body-font-family, sans-serif);
     font-weight: 400;
     font-size: 18px;
     color: var(--theme-palette-color-4, #888);
@@ -214,14 +214,14 @@ body .dgwt-wcas-suggestions-wrapp .dgwt-wcas-section-pages .dgwt-wcas-suggestion
 
 
 body .dgwt-wcas-suggestions-wrapp .dgwt-wcas-section-categories .dgwt-wcas-suggestion .dgwt-wcas-st {
-    font-family: 'Museo Sans', var(--theme-body-font-family, sans-serif);
+    font-family: var(--theme-font-family, Montserrat), var(--theme-body-font-family, sans-serif);
     font-weight: 500;
     font-size: 16px;
     color: var(--theme-palette-color-2, #393939);
 }
 
 body .dgwt-wcas-suggestions-wrapp .dgwt-wcas-section-blog .dgwt-wcas-suggestion .dgwt-wcas-st {
-    font-family: 'Museo Sans', var(--theme-body-font-family, sans-serif);
+    font-family: var(--theme-font-family, Montserrat), var(--theme-body-font-family, sans-serif);
     font-weight: 500;
     font-size: 16px;
     color: var(--theme-palette-color-2, #393939);
@@ -306,11 +306,11 @@ body .dgwt-wcas-suggestions-wrapp .dgwt-wcas-suggestion-product .dgwt-wcas-sd {
    ========================================================================== */
 
 body .dgwt-wcas-suggestions-wrapp .dgwt-wcas-suggestion-product .dgwt-wcas-st {
-    /* @date 2026-04-28 — switched to Quicksand 400 to match live + Figma 684:85958.
-       Live's /fonts/Museo-Sans-500.otf is 404 and paints Quicksand via Next.js
-       __font_77bc62 fallback; staging body customizer also loads Quicksand 400.
-       Prior Museo Sans 700 was the only override forcing inconsistent weight. */
-    font-family: 'Quicksand', var(--theme-body-font-family), sans-serif;
+    /* @date 2026-04-28 — switched to var(--theme-font-family, Montserrat) 400 to match live + Figma 684:85958.
+       Live's /fonts/Museo-Sans-500.otf is 404 and paints var(--theme-font-family, Montserrat) via Next.js
+       __font_77bc62 fallback; staging body customizer also loads var(--theme-font-family, Montserrat) 400.
+       Prior var(--theme-font-family, Montserrat) 700 was the only override forcing inconsistent weight. */
+    font-family: var(--theme-font-family, Montserrat), var(--theme-body-font-family), sans-serif;
     font-weight: 400;
     font-size: 18px;
     line-height: 24px;
@@ -318,7 +318,7 @@ body .dgwt-wcas-suggestions-wrapp .dgwt-wcas-suggestion-product .dgwt-wcas-st {
 }
 
 body .dgwt-wcas-suggestions-wrapp .dgwt-wcas-suggestion-product .dgwt-wcas-sp .woocommerce-Price-amount {
-    font-family: 'Museo Sans', var(--theme-body-font-family, sans-serif);
+    font-family: var(--theme-font-family, Montserrat), var(--theme-body-font-family, sans-serif);
     font-weight: 300;
     font-size: 15px;
     color: var(--theme-palette-color-2, #393939);
@@ -343,7 +343,7 @@ body .dgwt-wcas-suggestions-wrapp .dgwt-wcas-suggestion-product .dgwt-wcas-sp > 
 
 body .dgwt-wcas-suggestions-wrapp .dgwt-wcas-section-products .dgwt-wcas-view-all {
     background-color: var(--theme-palette-color-3, #746A5F);
-    font-family: 'Museo Sans', var(--theme-body-font-family, sans-serif);
+    font-family: var(--theme-font-family, Montserrat), var(--theme-body-font-family, sans-serif);
     font-weight: 700;
     font-size: 16px;
     line-height: 30px;

--- a/assets/css/components/wishlist-offcanvas.css
+++ b/assets/css/components/wishlist-offcanvas.css
@@ -171,13 +171,13 @@
 	padding: 14px 24px;
 	background: var(--theme-button-background-initial-color, #333);
 	color: var(--theme-button-text-initial-color, #fff);
-	border-radius: var(--theme-button-border-radius, 8px);
+	border-radius: var(--theme-button-border-radius, 4px);
 	font-size: 14px;
-	font-weight: 600;
+	font-weight: 500;
 	text-decoration: none;
 	text-align: center;
 	text-transform: uppercase;
-	letter-spacing: 0.5px;
+	letter-spacing: 0.6px;
 	transition: background 0.2s;
 	box-sizing: border-box;
 }
@@ -201,13 +201,13 @@
 	padding: 14px 24px;
 	background: var(--theme-button-background-initial-color, #333);
 	color: var(--theme-button-text-initial-color, #fff);
-	border-radius: var(--theme-button-border-radius, 8px);
+	border-radius: var(--theme-button-border-radius, 4px);
 	font-size: 14px;
-	font-weight: 600;
+	font-weight: 500;
 	text-decoration: none;
 	text-align: center;
 	text-transform: uppercase;
-	letter-spacing: 0.5px;
+	letter-spacing: 0.6px;
 	transition: background 0.2s;
 	box-sizing: border-box;
 }
@@ -412,20 +412,20 @@
 	height: 1px;
 }
 
-/* Title typography — customizer says Quicksand n5 14px. */
+/* Title typography — customizer says var(--theme-font-family, Montserrat) n5 14px. */
 .bc-minicart-suggested-grid [data-products] .ct-product-title,
 .bc-wishlist-suggested-grid [data-products] .ct-product-title {
-	--theme-font-family: Quicksand, Sans-Serif;
+	--theme-font-family: var(--theme-font-family, Montserrat), Sans-Serif;
 	--theme-font-weight: 500;
 	--theme-font-size: 14px;
 	--theme-link-initial-color: var(--theme-palette-color-3);
 	--theme-link-hover-color: var(--theme-palette-color-1);
 }
 
-/* Price typography — customizer says Quicksand n5 13px. */
+/* Price typography — customizer says var(--theme-font-family, Montserrat) n5 13px. */
 .bc-minicart-suggested-grid [data-products] .price,
 .bc-wishlist-suggested-grid [data-products] .price {
-	--theme-font-family: Quicksand, Sans-Serif;
+	--theme-font-family: var(--theme-font-family, Montserrat), Sans-Serif;
 	--theme-font-weight: 500;
 	--theme-font-size: 14px;
 }

--- a/assets/css/components/woo-archive.css
+++ b/assets/css/components/woo-archive.css
@@ -86,3 +86,23 @@
    Pulled until we have a Figma reference or design clarification.
    See ClickUp comment thread for next-step options (drop-shadow, circular
    backdrop, etc.) once design intent is confirmed. */
+
+/* Listing top-bar borders + result-count spacing (migrated 2026-06-04 from Customizer Additional CSS). */
+.woo-listing-top {
+	border-top: 1px solid rgb(192 192 192);
+	border-bottom: 1px solid rgb(192 192 192);
+	padding: 0.75rem 0;
+}
+.woo-listing-top + .woocommerce-result-count,
+.ct-pagination + .woocommerce-result-count {
+	font-size: 1rem;
+	line-height: 1.5rem;
+}
+.products + .woocommerce-result-count,
+.ct-pagination + .woocommerce-result-count {
+	margin-top: 1rem;
+	text-align: center;
+}
+.products + .woocommerce-result-count {
+	margin-top: 3rem;
+}

--- a/assets/css/components/woo-bogo.css
+++ b/assets/css/components/woo-bogo.css
@@ -1,0 +1,100 @@
+/**
+ * Smart Coupons BOGO — giveaway popup + floating button styling.
+ *
+ * Migrated 2026-06-04 from Customizer "Additional CSS" into the child theme (the correct home for
+ * engineering CSS — Additional CSS is last-resort only). Enqueued site-wide because the floating
+ * giveaway popup button can appear on any page where a BOGO offer applies (matches the prior
+ * Customizer behaviour). The selectors only match WebToffee Smart Coupons markup, so it's inert
+ * anywhere the popup isn't present.
+ */
+
+/* Floating popup button icon (bottom-right) — sized up to 75x75 per client request (2026-06-04). */
+.wbte_sc_bogo_popup_btn img {
+	width: 75px;
+	height: 75px;
+}
+
+/* Giveaway product tiles in the popup. */
+.wbte_sc_bogo_products li.wbte_get_away_product {
+	min-width: 215px;
+}
+
+/* Popup footer buttons. */
+.wbte_sc_giveaway_popup .wbte_sc_giveaway_popup_footer button.button {
+	background-color: #D9EAF0;
+	text-transform: uppercase;
+	color: #111111;
+	font-weight: 600;
+}
+
+.wbte_sc_giveaway_popup .wbte_sc_giveaway_popup_footer button.button.wbte_sc_bogo_add_to_cart {
+	background-color: #FFFFFF;
+	border: 1px solid #EAEBED;
+}
+
+/* Hide the quantity stepper inside the giveaway popup. */
+.wbte_sc_bogo_quantity {
+	display: none;
+}
+
+/* Giveaway popup title. */
+h4.giveaway-title {
+	border-bottom: 1px solid #E4E5E7;
+	padding-bottom: 12px;
+}
+
+/* Giveaway popup variation selectors. */
+.wbte_sc_giveaway_popup .ct-variation-swatches > select.wbte_give_away_product_attr {
+	display: block !important;
+	width: 100%;
+	padding: 8px 10px;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	background: #fff;
+}
+
+.wbte_sc_giveaway_popup .wt_variations td.value {
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 5px;
+}
+
+.wbte_sc_giveaway_popup .ct-variation-swatches .ct-swatch-container,
+.wbte_sc_giveaway_popup .ct-variation-swatches a.ct-swatches-more {
+	display: none;
+}
+
+.wbte_sc_giveaway_popup .wbte_product_name {
+	-webkit-line-clamp: none;
+}
+
+/* == Store-notice prominence + BOGO link spacing (Annemarie 2026-06-11) =======
+   Client report: the "you've unlocked a complimentary item" BOGO notice (and
+   coupon-applied notices) are too faint and get missed -- a couple of orders
+   were placed without the free gift. Also the merged category link renders with
+   no surrounding spaces ("ourCandles + Refill Candlescollection"): Blocksy's
+   flex notice layout collapses the whitespace around the link (which is its own
+   flex item) -- this is NOT a plugin bug; WebToffee outputs correct spaced HTML.
+   Fixes (all CSS):
+     1) give the info/success notices a clear on-brand sage background + accent
+        + readable 500 weight so they stand out;
+     2) restore the visual spaces around the category link + underline it.
+   Background colour is a single value -- easy to adjust to taste. */
+.woocommerce-info,
+.woocommerce-message,
+.wc-block-components-notice-banner {
+	background: #e6eed9 !important;
+	border: 1px solid #cdd9b4 !important;
+	border-left: 4px solid #84944f !important;
+	color: #3a3a3a !important;
+	font-weight: 500 !important;
+	padding-top: 14px !important;
+	padding-right: 18px !important;
+	padding-bottom: 14px !important;
+	/* left padding left to Blocksy (reserves space for the notice icon) */
+	border-radius: 6px !important;
+}
+.wt_sc_giveaway_category_link {
+	margin: 0 0.28em;
+	text-decoration: underline;
+}

--- a/assets/css/components/woo-cart.css
+++ b/assets/css/components/woo-cart.css
@@ -1,0 +1,22 @@
+/**
+ * woo-cart.css — Cart page tweaks.
+ *
+ * Loaded conditionally on is_cart() in inc/enqueue.php, and ONLY when
+ * bbc_smart_coupons_cart_css_active() passes — i.e. Smart Coupons' giveaway class
+ * exists AND the `bbc_smart_coupons_cart_css_enabled` filter is true (default).
+ * So this file never loads if the plugin is missing/inactive, and can be switched
+ * off without editing the theme.
+ *
+ * Smart Coupons BOGO giveaway: hide the per-product discount detail on the
+ * cart page. The `.wt_sc_giveaway_products_cart_page` wrapper only renders when
+ * WebToffee Smart Coupons outputs giveaway products, so the rule is also inert by
+ * design — even if it loaded it could not affect a cart without giveaway markup.
+ *
+ * Migrated 2026-06-03 from the Blocksy code-snippets extension (snippet #5
+ * "WebToffee Smart Coupons", wp_footer). Moving it into the child theme decouples
+ * the rule from `code-snippets` being present in blocksy_active_extensions, and
+ * lets the cutover script carry it automatically via the theme transfer.
+ */
+.wt_sc_giveaway_products_cart_page .wt_product_discount {
+	display: none;
+}

--- a/assets/css/components/woo-checkout.css
+++ b/assets/css/components/woo-checkout.css
@@ -39,12 +39,12 @@ body .fc-wrapper [data-step-complete] .fc-step__substep-save,
 	border-radius: 4px;
 	font-size: 16px;
 	line-height: 24px;
-	font-weight: 400;
+	font-weight: 500;
 	padding: 14px 24px;
 	min-height: 40px;
 	width: 100%;
 	text-transform: uppercase;
-	letter-spacing: 0.5px;
+	letter-spacing: 0.6px;
 	transition: background-color 0.2s;
 }
 
@@ -60,7 +60,7 @@ body .fc-wrapper [data-step-complete] .fc-step__substep-save,
 	color: var(--theme-palette-color-3, #333);
 	border: 1px solid var(--theme-palette-color-12, #E0DCD7);
 	border-radius: 4px;
-	font-weight: 400;
+	font-weight: 500;
 	padding: 14px 24px;
 	min-height: 40px;
 }

--- a/clients/byronbay/byronbay.css
+++ b/clients/byronbay/byronbay.css
@@ -1,3 +1,10 @@
+/* BC design tokens (byronbay.css — 86extrx5y, Jayr 2026-06-01) */
+:root {
+  --bc-swatch-hover-bg: #E6EAD9; /* #2 variation swatch hover tint */
+  --bc-menu-hover-bg:   #EEF1E5; /* #4 mega-menu link hover tint */
+  --bc-mega-heading-top: 15px;   /* #4 mega-menu heading top space — SINGLE LEVER: change here, applies everywhere it is used */
+}
+
 /**
  * Byron Bay Candles — Client-specific CSS overrides.
  *
@@ -297,7 +304,7 @@ label.wc-pao-addon-name[data-addon-name=Gift wrap] {
    @date 2026-04-28 (CU-86exduk1q): live renders Title Case (the wrapper
    anchor has Tailwind 'uppercase' but the inner button is text-transform:none,
    so visible text is "See More" not "SEE MORE"). Mirroring live's actual paint:
-   18px / Quicksand 400 / no letter-spacing / no uppercase. Color stays on the
+   18px / var(--theme-font-family, Montserrat) 400 / no letter-spacing / no uppercase. Color stays on the
    theme palette-3 var so it follows Elneil's customizer (Figma's CONTRAST 3
    token #746a5f vs staging palette-3 #655B51 is a separate designer call —
    tracked in the BBC Typography Reference doc). */
@@ -373,7 +380,8 @@ label.wc-pao-addon-name[data-addon-name=Gift wrap] {
 	min-width: 0;
 	text-transform: uppercase !important;
 	letter-spacing: 0.05em;
-	font-weight: 600 !important;
+	font-weight: 500 !important; /* #3 spec, was 600 (Jayr 2026-06-01) */
+	color: var(--theme-palette-color-24) !important; /* #3 text #3F3A36 */
 }
 
 .ct-cart-actions > .single_add_to_cart_button::after {
@@ -766,7 +774,7 @@ label.wc-pao-addon-name[data-addon-name=Gift wrap] {
 	padding: 10px 40px 10px 10px;
 	font-size: 16px;
 	font-weight: 400;
-	color: #888888;
+	color: var(--theme-palette-color-4, #888888);
 	line-height: 24px;
 	border: none;
 	border-radius: 6px;
@@ -802,7 +810,7 @@ label.wc-pao-addon-name[data-addon-name=Gift wrap] {
 [data-id="search"] .dgwt-wcas-search-wrapp .dgwt-wcas-search-form .dgwt-wcas-ico-magnifier {
 	width: 24px;
 	height: 24px;
-	fill: #888888;
+	fill: var(--theme-palette-color-4, #888888);
 }
 
 /* Phone number — prevent wrapping to two lines.
@@ -843,7 +851,7 @@ label.wc-pao-addon-name[data-addon-name=Gift wrap] {
 		padding: 10px 40px 10px 16px; /* QA 86exfx68w: align placeholder with icons-row gutter */
 		font-size: 16px;
 		font-weight: 400;
-		color: #888888;
+		color: var(--theme-palette-color-4, #888888);
 		line-height: 24px;
 		border: none;
 		border-radius: 6px;
@@ -871,7 +879,7 @@ label.wc-pao-addon-name[data-addon-name=Gift wrap] {
 	[data-device="mobile"] [data-id="search"] .dgwt-wcas-search-wrapp .dgwt-wcas-search-form .dgwt-wcas-ico-magnifier {
 		width: 24px;
 		height: 24px;
-		fill: #888888;
+		fill: var(--theme-palette-color-4, #888888);
 	}
 }
 
@@ -984,7 +992,7 @@ label.wc-pao-addon-name[data-addon-name=Gift wrap] {
 
 [data-header] #offcanvas .ct-panel-actions::before {
 	content: "Menu";
-	font-family: Museo Sans, var(--theme-body-font-family, sans-serif);
+	font-family: var(--theme-font-family, Montserrat), var(--theme-body-font-family, sans-serif);
 	font-size: 16px;
 	font-weight: 700;
 	color: var(--theme-palette-color-2, #393939);
@@ -1008,13 +1016,13 @@ label.wc-pao-addon-name[data-addon-name=Gift wrap] {
 	fill: var(--theme-palette-color-2, #393939) !important;
 }
 
-/* Menu link font — match live site (16px/500, Museo Sans).
+/* Menu link font — match live site (16px/500, var(--theme-font-family, Montserrat)).
    Blocksy default is 20px/700 which is too bold for this design.
    @date 2026-04-15 */
 [data-header] #offcanvas .ct-menu-link {
 	font-size: 16px !important;
 	font-weight: 500 !important;
-	font-family: Museo Sans, var(--theme-body-font-family, sans-serif) !important;
+	font-family: var(--theme-font-family, Montserrat), var(--theme-body-font-family, sans-serif) !important;
 }
 
 /* Menu item dividers — subtle lines between items.
@@ -1124,7 +1132,7 @@ body.woocommerce-checkout {
 	font-weight: 600;
 	letter-spacing: 0.12em;
 	text-transform: uppercase;
-	color: #888888;
+	color: var(--theme-palette-color-4, #888888);
 	margin-top: 24px;
 	margin-bottom: 8px;
 }
@@ -1217,7 +1225,7 @@ body.woocommerce-checkout {
 .bc-404 .dgwt-wcas-search-wrapp .dgwt-wcas-search-form .dgwt-wcas-ico-magnifier {
 	width: 24px;
 	height: 24px;
-	fill: #888888;
+	fill: var(--theme-palette-color-4, #888888);
 }
 
 /* CTA row — extra breathing room + consistent gap.
@@ -1634,7 +1642,7 @@ span.out-of-stock-badge,
 .single-product .summary .price del,
 .single-product .summary .price .woocommerce-Price-amount,
 .single-product .summary .price bdi {
-	font-size: 14px;
+	font-size: var(--theme-font-size, 24px);
 }
 
 /* BBC 86exbzech R6: floating bar price (ct-floating-bar-content) */
@@ -1668,4 +1676,500 @@ span.out-of-stock-badge,
 .ct-cart-actions > .quantity[data-type='type-2'] .ct-decrease:hover,
 .ct-cart-actions > .quantity[data-type='type-2'] .ct-increase:hover {
 	background: var(--theme-border-color, #e5e5e5) !important;
+}
+
+/* ==========================================================================
+   86extrx5y — PDP qty stepper: seamless grouped pill (client request 2026-06-01)
+   WHY: Blocksy native type-2 rules out-specify qty-stepper.css (buttons stayed
+   30px / 3px-radius, input 55px → three separate boxes, see CU image #3). This
+   high-specificity override (byronbay.css loads last) forces equal-height inline
+   cells with merged borders + outer-only radius. "Qty:" label stays outside.
+   Verified via Playwright computed styles (179x46 pill). @date 2026-06-01
+   ========================================================================== */
+.ct-cart-actions > .quantity[data-type='type-2'] { gap: 0 !important; align-items: center !important; }
+.ct-cart-actions > .quantity[data-type='type-2'] .ct-decrease,
+.ct-cart-actions > .quantity[data-type='type-2'] .ct-increase {
+	display: inline-flex !important; align-items: center !important; justify-content: center !important;
+	position: static !important; inset: auto !important;
+	height: 46px !important; width: 44px !important; min-height: 0 !important; box-sizing: border-box !important;
+	border: 1px solid #D8D1C7 !important; /* #2 spec — was rendering Blocksy form-field #cfcfcf via the var */
+	border-radius: 0 !important; background: #fff !important; box-shadow: none !important; cursor: pointer;
+}
+.ct-cart-actions > .quantity[data-type='type-2'] .ct-decrease { order: 0 !important; border-right: 0 !important; border-top-left-radius: 4px !important; border-bottom-left-radius: 4px !important; }
+.ct-cart-actions > .quantity[data-type='type-2'] .ct-increase { order: 2 !important; border-left: 0 !important; border-top-right-radius: 4px !important; border-bottom-right-radius: 4px !important; }
+.ct-cart-actions > .quantity[data-type='type-2'] .input-text.qty {
+	position: static !important; order: 1 !important; height: 46px !important; width: 52px !important;
+	min-height: 0 !important; box-sizing: border-box !important;
+	border: 1px solid #D8D1C7 !important; /* #2 spec — was rendering Blocksy form-field #cfcfcf via the var */
+	border-radius: 0 !important; background: #fff !important; text-align: center;
+}
+
+
+/* ==========================================================================
+   86extrx5y — PDP product-info row (Calculate Shipping | Return | FAQ): 3 even
+   columns. Consolidated 2026-06-01 (was 3 blocks). minmax(0,1fr) + min-width:0
+   forces equal thirds; divider margin reset keeps the auto columns thin.
+   ========================================================================== */
+.entry-summary .bc-product-info-items {
+	display: grid !important;
+	grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr) auto minmax(0, 1fr) !important;
+	align-items: center !important;
+	width: 100% !important;
+}
+.entry-summary .bc-product-info-items .bc-product-info-item {
+	width: auto !important;
+	min-width: 0 !important;
+	justify-content: center !important;
+	white-space: nowrap !important;
+}
+.entry-summary .bc-product-info-items .bc-product-info-divider {
+	margin-left: 0 !important;
+	margin-right: 0 !important;
+}
+
+/* ==========================================================================
+   86extrx5y — PDP summary box: fit content height + balanced padding (image #5)
+   Client request 2026-06-01: the bordered summary stretched to match the tall
+   gallery column (flex align stretch) leaving ~150px empty at the bottom.
+   align-self:flex-start → content-height (dynamic: shrinks when less content).
+   Zeroing the trailing element margin (afterpay carries 16px before an empty
+   Smart-Coupons block) makes bottom padding (24px) match top (24px).
+   ========================================================================== */
+.single-product .entry-summary { align-self: flex-start !important; }
+.single-product .entry-summary-items > *:last-child,
+.single-product .entry-summary-items > *:has(+ .available_coupons_with_product) { margin-bottom: 0 !important; }
+
+/* ==========================================================================
+   86extrx5y — floating/sticky add-to-cart bar qty stepper (image #6): match the
+   PDP pill. Same rules as .ct-cart-actions but scoped to .ct-floating-bar-actions
+   and sized compact (40px) for the slim sticky bar. @date 2026-06-01
+   ========================================================================== */
+.ct-floating-bar-actions .quantity[data-type='type-2'] { gap: 0 !important; align-items: center !important; }
+.ct-floating-bar-actions .quantity[data-type='type-2'] .ct-decrease,
+.ct-floating-bar-actions .quantity[data-type='type-2'] .ct-increase {
+	display: inline-flex !important; align-items: center !important; justify-content: center !important;
+	position: static !important; inset: auto !important;
+	height: 40px !important; width: 38px !important; min-height: 0 !important; box-sizing: border-box !important;
+	border: 1px solid #D8D1C7 !important; /* #2 spec — was rendering Blocksy form-field #cfcfcf via the var */
+	border-radius: 0 !important; background: #fff !important; box-shadow: none !important; cursor: pointer;
+}
+.ct-floating-bar-actions .quantity[data-type='type-2'] .ct-decrease { order: 0 !important; border-right: 0 !important; border-top-left-radius: 4px !important; border-bottom-left-radius: 4px !important; }
+.ct-floating-bar-actions .quantity[data-type='type-2'] .ct-increase { order: 2 !important; border-left: 0 !important; border-top-right-radius: 4px !important; border-bottom-right-radius: 4px !important; }
+.ct-floating-bar-actions .quantity[data-type='type-2'] .input-text.qty {
+	position: static !important; order: 1 !important; height: 40px !important; width: 46px !important;
+	min-height: 0 !important; box-sizing: border-box !important;
+	border: 1px solid #D8D1C7 !important; /* #2 spec — was rendering Blocksy form-field #cfcfcf via the var */
+	border-radius: 0 !important; background: #fff !important; text-align: center;
+}
+
+/* ==========================================================================
+   86extrx5y — #1 Variation Labels typography (client 2026-06-01)
+   Montserrat 500 · 14px · letter-spacing 0.02em · #4A433D (palette color29).
+   Was Montserrat 600 / 18px / #5B554F.
+   ========================================================================== */
+.single-product .variations th.label,
+.single-product .variations th.label label {
+	font-family: var(--theme-font-family, Montserrat, sans-serif) !important;
+	font-weight: 500 !important;
+	font-size: 14px !important;
+	letter-spacing: 0.02em !important;
+	color: var(--theme-palette-color-29, #4A433D) !important;
+}
+
+/* ==========================================================================
+   86extrx5y — #2 Product Variation Button (swatch) styling (client 2026-06-01)
+   Kills the harsh black selected state; soft brand palette. Selected colours use
+   palette tokens (color12/13/24 = #DDE2CF/#C5CDB4/#3F3A36); unselected text = color29
+   (#4A433D); unselected border = client literal #D8D1C7; hover bg #E6EAD9.
+   ========================================================================== */
+.single-product .ct-variation-swatches .ct-swatch {
+	background: #FFFFFF !important;
+	border: 1px solid #D8D1C7 !important; /* #2 spec — was rendering Blocksy form-field #cfcfcf via the var */
+	color: var(--theme-palette-color-29, #4A433D) !important;
+	border-radius: 4px !important;
+	padding: 8px 16px !important;
+}
+.single-product .ct-variation-swatches .ct-swatch-container.active .ct-swatch {
+	background: var(--theme-palette-color-12, #DDE2CF) !important;
+	border-color: var(--theme-palette-color-13, #C5CDB4) !important;
+	color: var(--theme-palette-color-24, #3F3A36) !important;
+}
+.single-product .ct-variation-swatches .ct-swatch:hover {
+	background: var(--bc-swatch-hover-bg, #E6EAD9) !important;
+	border-color: var(--theme-palette-color-13, #C5CDB4) !important;
+	color: var(--theme-palette-color-24, #3F3A36) !important;
+}
+.single-product .ct-variation-swatches .ct-swatch-container {
+	margin: 0 10px 10px 0 !important;
+}
+
+/* ==========================================================================
+   86extrx5y — #1 Body/Description text + layout spacing (client 2026-06-01)
+   Body: Montserrat 400 · 17px · line-height 1.8 · #5B554F (color25). Was 18px/1.75.
+   Spacing: bump --product-element-spacing 16px → 24px for editorial breathing room.
+   ========================================================================== */
+.single-product .entry-summary-items > * { --product-element-spacing: 24px; }
+.single-product [id*="tab-description"],
+.single-product [id*="tab-description"] p,
+.single-product [id*="tab-description"] li {
+	font-family: var(--theme-font-family, Montserrat, sans-serif) !important;
+	font-weight: 400 !important;
+	font-size: 17px !important;
+	line-height: 1.8 !important;
+	color: var(--theme-palette-color-25, #5B554F) !important;
+}
+
+/* ==========================================================================
+   86extrx5y — #1 layout spacing (client 2026-06-01): more breathing room in the
+   upper summary. Scoped to title/price/stock margins so it can't disturb the
+   summary-box bottom-padding fix (which manages the lower elements).
+   ========================================================================== */
+.single-product .entry-summary-items > .product_title,
+.single-product .entry-summary-items > .price,
+.single-product .entry-summary-items > .bc-stock-status { margin-bottom: 24px !important; }
+
+/* ==========================================================================
+   86extrx5y — #4 Mega Menu (client 2026-06-01)
+   Base links already uniform 500/16px/no-underline (no bold/underlined headers).
+   This adds: calm hover (#EEF1E5 / #4A433D=color29), no active-parent/column
+   highlight, consistent weight, and more link spacing/breathing room.
+   ========================================================================== */
+.sub-menu a { font-weight: 500 !important; text-decoration: none !important; }
+.sub-menu li > a { border-radius: 6px !important; } /* padding now from Blocksy --menu-item-padding (Customizer Items Spacing); child override removed 2026-06-02 */
+.sub-menu li > a:hover,
+.sub-menu li > a:focus-visible {
+	background: var(--bc-menu-hover-bg, #EEF1E5) !important;
+	color: var(--theme-palette-color-29, #4A433D) !important;
+}
+.sub-menu .current-menu-item > a,
+.sub-menu .current-menu-ancestor > a,
+.sub-menu .current-menu-parent > a {
+	background: transparent !important;
+	font-weight: 500 !important;
+	color: inherit !important;
+}
+/* item spacing now governed by Blocksy Customizer dropdownItemsSpacing (13px); child 2px override removed 2026-06-02 */
+
+/* ==========================================================================
+   86extrx5y — Variation swatch option text weight + tracking (client 2026-06-01)
+   The scent-option labels (.ct-swatch text) were 600 / 0.18px → spec is 500 /
+   letter-spacing 0.02em (= 0.28px at 14px). Size 14px + colour #4A433D already set.
+   ========================================================================== */
+.single-product .ct-variation-swatches .ct-swatch,
+.single-product .ct-variation-swatches .ct-swatch-content {
+	font-weight: 500 !important;
+	letter-spacing: 0.02em !important;
+}
+
+/* #3 sitewide primary button text colour + weight. WHY: Blocksy buttonTextColor (=color-24) is not emitted into dynamic CSS, so primary buttons render default #111 / stray weights. Scope: solid/primary only; ghost+wishlist+icon excluded. Jayr 2026-06-01 #86extrx5y */
+.woocommerce a.button.alt,
+.woocommerce button.button.alt,
+.woocommerce .single_add_to_cart_button,
+.woocommerce button.button:not(.ct-button-ghost),
+.woocommerce input.button:not(.ct-button-ghost),
+.wp-block-button__link,
+.ct-button:not(.ct-button-ghost) {
+	color: var(--theme-palette-color-24) !important;
+	font-weight: 500 !important;
+	font-size: 17px !important; /* #3 spec button size 17px, Jayr 2026-06-02 */
+}
+
+/* #3 anchor-based primary buttons (See More / View cart) missed by the button.alt selector. Jayr 2026-06-01 #86extrx5y */
+.woocommerce a.button:not(.ct-button-ghost),
+.bc-see-more-link {
+	color: var(--theme-palette-color-24) !important;
+	font-weight: 500 !important;
+	font-size: 17px !important; /* #3 spec button size 17px, Jayr 2026-06-02 */
+}
+
+
+/* ==========================================================================
+   86extrx5y - mini-cart / off-canvas "Your bag" drawer qty stepper
+   (client request 2026-06-01). Match the PDP (.ct-cart-actions) + sticky
+   (.ct-floating-bar-actions) seamless grouped pill, but COMPACT for the slim
+   drawer (~34px). Blocksy's lazy-loaded cart-header-element-lazy.min.css loads
+   AFTER byronbay.css and after qty-stepper.css, so its native
+   .quantity[data-type='type-2'] rules out-specified the component knob
+   overrides in offcanvas.css (buttons rendered ~19px tall with per-button 3px
+   radius -> three separate boxes). This high-specificity !important block
+   (byronbay.css loads last among child CSS; mini-cart-scoped + !important beats
+   the lazy Blocksy stylesheet) forces the seamless pill: merged borders +
+   outer-only 8px radius, decrease/input/increase inline at equal 34px height.
+   Scoped to both #woo-cart-panel (drawer) and .woocommerce-mini-cart (fragment
+   contexts). Verified via served-CSS + computed styles (Playwright stateful
+   click chains unreliable in this env). @date 2026-06-01
+   ========================================================================== */
+#woo-cart-panel .ct-product-actions > .quantity[data-type='type-2'],
+.woocommerce-mini-cart .ct-product-actions > .quantity[data-type='type-2'] { gap: 0 !important; align-items: center !important; }
+#woo-cart-panel .ct-product-actions > .quantity[data-type='type-2'] .ct-decrease,
+#woo-cart-panel .ct-product-actions > .quantity[data-type='type-2'] .ct-increase,
+.woocommerce-mini-cart .ct-product-actions > .quantity[data-type='type-2'] .ct-decrease,
+.woocommerce-mini-cart .ct-product-actions > .quantity[data-type='type-2'] .ct-increase {
+	display: inline-flex !important; align-items: center !important; justify-content: center !important;
+	position: static !important; inset: auto !important;
+	height: 34px !important; width: 30px !important; min-height: 0 !important; box-sizing: border-box !important;
+	border: 1px solid #D8D1C7 !important; /* #2 spec — was rendering Blocksy form-field #cfcfcf via the var */
+	border-radius: 0 !important; background: #fff !important; box-shadow: none !important; cursor: pointer;
+}
+#woo-cart-panel .ct-product-actions > .quantity[data-type='type-2'] .ct-decrease,
+.woocommerce-mini-cart .ct-product-actions > .quantity[data-type='type-2'] .ct-decrease { order: 0 !important; border-right: 0 !important; border-top-left-radius: 4px !important; border-bottom-left-radius: 4px !important; }
+#woo-cart-panel .ct-product-actions > .quantity[data-type='type-2'] .ct-increase,
+.woocommerce-mini-cart .ct-product-actions > .quantity[data-type='type-2'] .ct-increase { order: 2 !important; border-left: 0 !important; border-top-right-radius: 4px !important; border-bottom-right-radius: 4px !important; }
+#woo-cart-panel .ct-product-actions > .quantity[data-type='type-2'] .input-text.qty,
+.woocommerce-mini-cart .ct-product-actions > .quantity[data-type='type-2'] .input-text.qty {
+	position: static !important; order: 1 !important; height: 34px !important; width: 40px !important;
+	min-height: 0 !important; box-sizing: border-box !important;
+	border: 1px solid #D8D1C7 !important; /* #2 spec — was rendering Blocksy form-field #cfcfcf via the var */
+	border-radius: 0 !important; background: #fff !important; text-align: center;
+}
+
+
+/* ==========================================================================
+   86extrx5y #5 - WebToffee Smart Coupons Pro BOGO free-gift chooser button
+   (client request 2026-06-01, option A: enlarge for discoverability).
+   Plugin markup: <div class='wbte_sc_bogo_popup_btn bottom-right'><img
+   src='bogo_popup_btn.svg'></div>. Plugin base style.css ships the button
+   at 50x50px with a 24x24px inner <img>. byronbay.css loads LAST among child
+   CSS so this !important block out-specifies the plugin's assets/style.css.
+   Sized container to 75x75 AND scale the inner <img> proportionally
+   (48x48 with padding) so the glyph fills the circle instead of sitting tiny
+   in a big box. Position (fixed, bottom-right) left untouched. Verified via
+   served-CSS + on-server brace balance; live visual confirm by Jayr (BOGO
+   offer is cart-session-stateful, Playwright resets context here). \@date 2026-06-01
+   ========================================================================== */
+.wbte_sc_bogo_popup_btn { width: 75px !important; height: 75px !important; padding: 0 !important; box-sizing: border-box !important; }
+.wbte_sc_bogo_popup_btn img { width: 75px !important; height: 75px !important; max-width: 100% !important; max-height: 100% !important; }
+
+
+/* ==========================================================================
+   86extrx5y #3 - WebToffee Smart Coupons Pro BOGO popup CTA buttons
+   (client request 2026-06-01). The sitewide #3 primary-button override is
+   scoped under .woocommerce, but the BOGO free-gift popup is body-appended
+   (outside .woocommerce), so its CTA buttons fell back to plugin/theme
+   default. Re-apply the client #3 primary-button spec directly on the BOGO
+   CTA selectors. byronbay.css loads LAST among child CSS so this !important
+   block out-specifies the plugin's public/modules/bogo/assets/style.css.
+   Front-end customer CTAs only:
+     .wbte_sc_bogo_add_to_cart        -> 'Add to cart'
+     .wbte_sc_bogo_proceed_checkout   -> 'Add & go to checkout'
+   Admin/'add new'/dropdown buttons (wbte_sc_bogo_add_new_*, *_edit_*)
+   are intentionally NOT styled. Color/hover/text/font/radius only - no
+   padding/layout changes. Verified via served-CSS + on-server brace
+   balance; live visual confirm by Jayr (BOGO offer is cart-session-
+   stateful, Playwright resets context here). \@date 2026-06-01
+   ========================================================================== */
+.wbte_sc_bogo_add_to_cart,
+.wbte_sc_bogo_proceed_checkout {
+	background: var(--theme-palette-color-12, #DDE2CF) !important;
+	color: var(--theme-palette-color-24, #3F3A36) !important;
+	font-family: 'Montserrat', sans-serif !important;
+	font-weight: 500 !important;
+	letter-spacing: 0.6px !important;
+	border-radius: 4px !important;
+}
+.wbte_sc_bogo_add_to_cart:hover,
+.wbte_sc_bogo_add_to_cart:focus,
+.wbte_sc_bogo_proceed_checkout:hover,
+.wbte_sc_bogo_proceed_checkout:focus {
+	background: var(--theme-palette-color-13, #C5CDB4) !important;
+	color: var(--theme-palette-color-24, #3F3A36) !important;
+}
+
+
+/* ==========================================================================
+   86extrx5y — #4 Mega Menu headings = links (client 2026-06-02)
+   Supersedes the 2026-02-25 "Heading & Divider Styling". Client wants column
+   headings to MATCH the links: consistent size + weight, no bold, no underline
+   divider, no oversized headings. Neutralises that earlier treatment.
+   ========================================================================== */
+nav > ul > [class*="ct-mega-menu"] > .sub-menu > li:has(> .ct-column-heading) {
+	border-bottom: none !important;
+	padding-bottom: 0 !important; /* remove leftover Feb 12px row padding under full-width heading */
+}
+nav > ul > [class*="ct-mega-menu"] > .sub-menu > li > .ct-column-heading,
+nav > ul > .byronbay-mega-candles > .sub-menu > li.menu-item-has-children > .ct-menu-link,
+nav > ul > .byronbay-mega-diffusers > .sub-menu > li.menu-item-has-children > .ct-menu-link {
+	font-weight: 500 !important;
+	font-size: 13px !important;
+	border-bottom: none !important;
+	padding: var(--menu-item-padding, 11px 14px) !important; /* balanced top/bottom = same as items */
+	margin-bottom: 0 !important;
+}
+
+/* ==========================================================================
+   86extrx5y — #4b Mega Menu heading spacing + no-highlight (client 2026-06-02)
+   (a) ~5px breathing room below column headings (was too tight after the
+       divider was removed). (b) Column HEADINGS are not clickable "items" —
+       remove their hover/focus highlight so ONLY leaf items highlight
+       (client: "only the individual hovered/selected menu item should highlight").
+   Leaf items are NOT .menu-item-has-children, so they keep their hover tint.
+   ========================================================================== */
+/* (removed 2026-06-02) heading links ARE category links -> they now follow the normal
+   hover pill (#EEF1E5) like any item. #4d still keeps non-hover states transparent,
+   so a heading only highlights when hovered directly, not persistently. */
+
+/* ==========================================================================
+   86extrx5y — #4c Mega Menu: ONLY the hovered item may highlight (client 2026-06-02)
+   Root cause traced to BLOCKSY (headerDropdownBackground / current-item state),
+   not the child theme. This bulletproofs the client rule: every dropdown link
+   that is NOT currently hovered is forced to a transparent background, so no
+   persistent/current/active/JS-applied highlight can linger on a column heading.
+   Keyboard focus (:focus-visible) is preserved for accessibility.
+   ========================================================================== */
+/* #4d (2026-06-02): persistent highlight OFF, hover tint restored. The #4c
+   :not(:hover) rule suppressed the visible hover; enumerate states instead so the
+   HOVERED item highlights (#EEF1E5) while no base/focus/active/current state lingers
+   on a heading. Also trims the full-width heading bottom padding (~half). */
+nav .sub-menu li > a,
+nav .sub-menu li > a:focus,
+nav .sub-menu li > a:active,
+nav .sub-menu .current-menu-item > a,
+nav .sub-menu .current-menu-parent > a,
+nav .sub-menu .current-menu-ancestor > a {
+	background: transparent !important;
+}
+nav .sub-menu li > a:hover,
+nav .sub-menu li > a:focus-visible {
+	background: var(--bc-menu-hover-bg, #EEF1E5) !important;
+	color: var(--theme-palette-color-29, #4A433D) !important;
+}
+
+
+/* ==========================================================================
+   86extrx5y — #4e Mega Menu grid row-gap (client 2026-06-02)
+   The big gap below the full-width heading + column headings is the mega-menu
+   GRID row-gap (scaled up when Items Spacing was set to 18px). Tighten just the
+   vertical grid gap; item-to-item spacing inside columns is unaffected.
+   ========================================================================== */
+nav > ul > [class*="ct-mega-menu"] > .sub-menu {
+	row-gap: 8px !important;
+}
+
+/* ==========================================================================
+   86extrx5y — #4f Full-width heading compact padding (client 2026-06-02)
+   The full-width "Scented Diffusers" label (.ct-column-heading, disabled, no
+   hover pill) had ~11px balanced padding that widened the gap to the columns
+   below. It shows no pill, so give it minimal balanced padding to tighten the
+   gap. Clickable headings keep their balanced pill padding (unaffected).
+   ========================================================================== */
+nav > ul > [class*="ct-mega-menu"] > .sub-menu > li > a.ct-column-heading {
+	padding-top: var(--bc-mega-heading-top, 15px) !important; /* uses shared lever --bc-mega-heading-top */
+	padding-bottom: 3px !important;
+}
+
+/* ==========================================================================
+   86extrx5y — #4g Mega Menu columns vertical padding (client 2026-06-02)
+   ROOT CAUSE of the big gap below headings: each mega column <li> (incl. the
+   full-width heading row) has padding: var(--columns-padding, 20px 30px) — i.e.
+   20px top+bottom per column. Heading bottom 20px + column top 20px stacked into
+   a big gap. Reduce the vertical of --columns-padding to 8px; keep 30px gutters.
+   ========================================================================== */
+nav > ul > [class*="ct-mega-menu"] > .sub-menu {
+	--columns-padding: 8px 30px;
+}
+
+/* ==========================================================================
+   Mobile / off-canvas menu — force Montserrat (client 2026-06-02)
+   The off-canvas menu still rendered var(--theme-font-family, Montserrat) despite mobileMenuFont=Montserrat
+   in theme_mods (a CSS rule was overriding it). Align to Montserrat sitewide.
+   ========================================================================== */
+[data-header] #offcanvas .ct-menu-link,
+[data-header] #offcanvas .ct-mobile-menu a,
+#offcanvas .ct-panel-inner .ct-menu-link {
+	font-family: var(--theme-font-family, Montserrat), sans-serif !important;
+}
+
+/* ==========================================================================
+   86extrx5y — #3b Primary buttons: hover darken + consistent letter-spacing
+   (client 2026-06-02). RENDERED QA found primary buttons (Add to Cart, See More)
+   were NOT darkening on hover (stayed #DDE2CF) and "See More" had letter-spacing:
+   normal. Enforce client #3: hover bg #C5CDB4 + text #3F3A36, letter-spacing 0.6px.
+   ========================================================================== */
+.woocommerce a.button.alt,
+.woocommerce button.button.alt,
+.woocommerce .single_add_to_cart_button,
+.woocommerce button.button:not(.ct-button-ghost),
+.woocommerce input.button:not(.ct-button-ghost),
+.wp-block-button__link,
+.ct-button:not(.ct-button-ghost),
+.woocommerce a.button:not(.ct-button-ghost),
+.bc-see-more-link {
+	letter-spacing: 0.6px !important;
+}
+.woocommerce a.button.alt:hover, .woocommerce a.button.alt:focus-visible,
+.woocommerce button.button.alt:hover, .woocommerce button.button.alt:focus-visible,
+.woocommerce .single_add_to_cart_button:hover, .woocommerce .single_add_to_cart_button:focus-visible,
+.woocommerce button.button:not(.ct-button-ghost):hover, .woocommerce button.button:not(.ct-button-ghost):focus-visible,
+.woocommerce input.button:not(.ct-button-ghost):hover, .woocommerce input.button:not(.ct-button-ghost):focus-visible,
+.wp-block-button__link:hover, .wp-block-button__link:focus-visible,
+.ct-button:not(.ct-button-ghost):hover, .ct-button:not(.ct-button-ghost):focus-visible,
+.woocommerce a.button:not(.ct-button-ghost):hover, .woocommerce a.button:not(.ct-button-ghost):focus-visible,
+.bc-see-more-link:hover, .bc-see-more-link:focus-visible {
+	background-color: var(--theme-palette-color-13, #C5CDB4) !important;
+	color: var(--theme-palette-color-24, #3F3A36) !important;
+}
+
+/* ==========================================================================
+   Product-card wishlist heart (.ct-wishlist-button-archive) — white all states
+   (client 2026-06-02). Blocksy default was grey #888 initial / black when added
+   (looked awful). No Customizer field exists for the card wishlist button bg, so
+   edited here. White circle in initial/hover/active; heart kept dark for contrast.
+   NOT in the QA list yet — Jayr verifying manually (not in client feedback).
+   ========================================================================== */
+[data-products] .ct-wishlist-button-archive,
+.ct-wishlist-button-archive,
+.ct-wishlist-button-archive:hover,
+.ct-wishlist-button-archive:focus,
+.ct-wishlist-button-archive:focus-visible,
+.ct-wishlist-button-archive[data-button-state="added"],
+.ct-wishlist-button-archive.active {
+	background-color: #FFFFFF !important;
+	color: var(--theme-palette-color-24, #3F3A36) !important;
+	border: 1px solid var(--theme-palette-color-13, #C5CDB4) !important; /* sage border = hover bg colour, so the white circle reads on product images */
+}
+
+/* ==========================================================================
+   BBC client styling feedback — 2026-06-03   (ClickUp 86exuq8gz)
+   #1 SALE/HOT badges -> approved palette · #2 Kadence dividers blue->sage ·
+   #5 content text-links WP-default-blue -> brand brown.
+   byronbay.css loads LAST -> overrides Woo/Kadence/WP defaults.
+   Rendered-verified: SALE #111111, HOT #EF4444, divider #3182CE, links #0693E3.
+   ========================================================================== */
+
+/* --- #1  Product badges -------------------------------------------------- */
+.onsale,
+.woocommerce span.onsale,
+li.product .onsale,
+.ct-woo-badges .onsale {
+	background-color: #4A433D !important;   /* SALE: deep brand brown (was #111 near-black) */
+	color: #FFFFFF !important;
+}
+.ct-woo-badge-featured,
+.ct-woo-badges .ct-woo-badge-featured {
+	background-color: #DDE2CF !important;   /* HOT: accent sage (was #EF4444 red) */
+	color: #3F3A36 !important;
+}
+
+/* --- #2  Kadence dividers: blue (#3182CE) -> sage ------------------------ */
+hr.kt-divider,
+.kt-divider,
+.wp-block-kadence-advancedheading hr.kt-divider {
+	border-color: #C5CDB4 !important;
+	border-top-color: #C5CDB4 !important;
+}
+
+/* --- #5  Body/content text links: WP default blue -> brand brown ---------
+   COLOR-ONLY (no underline — not in client feedback). Scoped to editorial text
+   so it does NOT touch WooCommerce product-card titles/images (li.product).
+   Revised 2026-06-03 after underline over-reach on Favourite Buys cards. */
+.entry-content p a:not([class*="button"]):not(.woocommerce-LoopProduct-link):not(.ct-media-container),
+.entry-content li:not(.product) a:not([class*="button"]):not(.woocommerce-LoopProduct-link):not(.ct-media-container),
+.wp-block-accordion a:not([class*="button"]),
+.wp-block-post-content p a:not([class*="button"]) {
+	color: #4A433D !important;
+}
+.entry-content p a:not([class*="button"]):hover,
+.entry-content li:not(.product) a:not([class*="button"]):hover,
+.wp-block-accordion a:not([class*="button"]):hover {
+	color: #7A746E !important;
 }

--- a/docs/patterns/offcanvas.md
+++ b/docs/patterns/offcanvas.md
@@ -225,3 +225,9 @@ Bound to: `wc_fragments_refreshed`, `wc_fragments_loaded`, `added_to_cart`, `rem
 
 - **[drawer-suggested-products.md](drawer-suggested-products.md)** — Master doc for the suggested-products carousel (7-state matrix, 8-layer bulletproofing). State #1 (mini cart with items) renders inside `.bc-cart-scroll` per the unified-scroll architecture above.
 - **[wishlist-offcanvas.md](wishlist-offcanvas.md)** — Wishlist drawer specifics (data sync, panel open/close)
+
+### 2026-06-09 — client weight override
+Annemarie requested regular-weight drawer text. An override block in offcanvas.css
+sets product title/price (was 500), SUBTOTAL (Blocksy 700) and Order Total + value
+(was 600) to font-weight 400 !important. Design-spec weights remain above the block;
+the override is the live state. Reverse by deleting that block.

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -154,12 +154,20 @@ function blocksy_child_enqueue_styles() {
 				blocksy_child_enqueue_component( 'checkout-trust-badges', $css_url, $css_path );
 			}
 		}
-		// Removed dead enqueue refs 2026-05-07 (audit P0.2):
-		// • is_cart() → woo-cart.css — file never existed, helper silently skipped
-		// • is_account_page() → woo-account.css — same
+		// Cart page — woo-cart.css. Migrated 2026-06-03 from Blocksy code-snippet
+		// #5 ("WebToffee Smart Coupons", wp_footer) so it no longer depends on the
+		// code-snippets extension (dropped from blocksy_active_extensions). The CSS
+		// only hides the BOGO giveaway "discount detail", so it is GUARDED to load
+		// ONLY when Smart Coupons' giveaway feature is genuinely active, and can be
+		// switched off site-wide via the `bbc_smart_coupons_cart_css_enabled` filter
+		// (no theme edit needed). If the plugin is missing/inactive/half-installed
+		// the file is never enqueued. See bbc_smart_coupons_cart_css_active().
+		if ( is_cart() && bbc_smart_coupons_cart_css_active() ) {
+			blocksy_child_enqueue_component( 'woo-cart', $css_url, $css_path );
+		}
+		// Removed dead enqueue refs 2026-05-07 (audit P0.2), re-add file + enqueue together if revived:
+		// • is_account_page() → woo-account.css — file never existed, helper silently skipped
 		// • unconditional → footer.css — same
-		// If page-specific styles are needed later, add the file under
-		// assets/css/components/ AND re-add the matching enqueue here together.
 	}
 
 if ( is_front_page() || ( function_exists("is_page") && is_page(645912) ) ) {
@@ -190,6 +198,11 @@ if ( is_front_page() || ( function_exists("is_page") && is_page(645912) ) ) {
 	// 3e. Breadcrumb mobile horizontal scroll -- loaded globally
 	//     (breadcrumbs render on PDP, archives, single posts, pages).
 	blocksy_child_enqueue_component( 'breadcrumbs', $css_url, $css_path );
+
+	// 3f. Smart Coupons BOGO giveaway popup styling -- loaded globally (the floating giveaway popup
+	//     button can appear on any page where a BOGO offer applies). Migrated 2026-06-04 from
+	//     Customizer Additional CSS into the child theme (runbook §13.18). Inert without BOGO markup.
+	blocksy_child_enqueue_component( 'woo-bogo', $css_url, $css_path );
 
 	// 3c. Wishlist off-canvas JS -- trigger, refresh, remove.
 	$js_path = BLOCKSY_CHILD_PATH . 'assets/js/wishlist-offcanvas.js';
@@ -276,6 +289,35 @@ if ( is_front_page() || ( function_exists("is_page") && is_page(645912) ) ) {
  * @param string $css_url   URL to assets/css/ directory.
  * @param string $css_path  Filesystem path to assets/css/ directory.
  */
+/**
+ * Whether the Smart Coupons cart CSS (woo-cart.css) should load.
+ *
+ * Guards the BOGO giveaway "discount detail" hide migrated 2026-06-03 from Blocksy
+ * code-snippet #5. Because this rule is client-specific (WebToffee Smart Coupons),
+ * it is decoupled from the theme's always-on CSS and gated three ways:
+ *
+ *   1. On/off switch — the `bbc_smart_coupons_cart_css_enabled` filter (default true).
+ *      Return false anywhere (mu-plugin, Customizer toggle, snippet) to disable it
+ *      site-wide WITHOUT editing the child theme.
+ *   2. Plugin-present check — class_exists() for the Smart Coupons giveaway class
+ *      (mirrors the original snippet's guard). Covers "plugin not installed right":
+ *      deactivated, half-installed, or a renamed build all fall through to false.
+ *   3. Inert by design — even if it somehow loaded, the selector only matches markup
+ *      that Smart Coupons emits, so it can never affect a cart without giveaways.
+ *
+ * @return bool
+ */
+function bbc_smart_coupons_cart_css_active() {
+	// 1. Explicit on/off switch (default ON).
+	if ( ! apply_filters( 'bbc_smart_coupons_cart_css_enabled', true ) ) {
+		return false;
+	}
+
+	// 2. Only load when Smart Coupons' giveaway feature is genuinely present.
+	return class_exists( 'Wt_Smart_Coupon_Giveaway_Product' )
+		|| class_exists( 'Wt_Smart_Coupon' );
+}
+
 function blocksy_child_enqueue_component( $component, $css_url, $css_path ) {
 	$file = $css_path . 'components/' . $component . '.css';
 

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -423,3 +423,72 @@ function bc_filter_cart_panel_heading( $translation, $text, $domain ) {
 		. ' <span class="ct-cart-panel-title">' . esc_html__( 'Your bag', 'blocksy-child' ) . '</span>'
 		. ' <span class="ct-cart-panel-count">(<span class="ct-cart-count-number">' . esc_html( (string) $count ) . '</span>)</span>';
 }
+
+/* 86extrx5y #6 — Archive cards must open the product page, never ajax add-to-cart (client request 2026-05-28). Priority 20 runs after the See More filter (10); covers simple products that previously fell through to the native ajax button. Remove this block to revert. */
+add_filter( 'woocommerce_loop_add_to_cart_link', function ( $link, $product, $args ) {
+	$bc_more = 'See More <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" class="bc-see-more-arrow" width="20" height="20"><path fill-rule="evenodd" d="M3 10a.75.75 0 01.75-.75h10.638L10.23 5.29a.75.75 0 111.04-1.08l5.5 5.25a.75.75 0 010 1.08l-5.5 5.25a.75.75 0 11-1.04-1.08l4.158-3.96H3.75A.75.75 0 013 10z" clip-rule="evenodd"></path></svg>';
+	return sprintf( '<a href="%s" class="button bc-see-more-link">%s</a>', esc_url( $product->get_permalink() ), $bc_more );
+}, 20, 3 );
+
+/**
+ * Hide the WooCommerce "Free Shipping" method at checkout for wholesale customers.
+ *
+ * Migrated 2026-06-04 from Code Snippets #11 ("Hide Free Shipping for Wholesale") into the child theme
+ * so the Code Snippets plugin can be removed, then hardened to BC child-theme conventions:
+ *   - function_exists() guard       → no fatal redeclaration if the old snippet is ever still active.
+ *   - master on/off filter          → `bbc_hide_free_shipping_for_wholesale_enabled` (default true);
+ *                                      return false anywhere (mu-plugin/snippet) to disable site-wide
+ *                                      WITHOUT editing the theme. Mirrors bbc_smart_coupons_cart_css_active().
+ *   - dependency-safe               → only runs inside a real WooCommerce shipping calc; if B2B Suite or
+ *                                      the roles are gone the role match simply finds nothing → no-op,
+ *                                      no errors. Nothing here hard-depends on B2B Suite being active.
+ *   - portable / configurable roles → target roles via `bbc_free_shipping_hidden_roles` so a site with
+ *                                      different B2B Suite role IDs can override without touching the theme
+ *                                      (role post-IDs differ per environment — verified sitebuild vs live).
+ *
+ * @param array $rates   WC_Shipping_Rate[] keyed by rate id.
+ * @param array $package The shipping package.
+ * @return array Filtered rates.
+ */
+if ( ! function_exists( 'bbc_hide_free_shipping_for_wholesale' ) ) {
+	function bbc_hide_free_shipping_for_wholesale( $rates, $package ) {
+		// 1. Master on/off switch (default ON). Turn off site-wide without editing the theme.
+		if ( ! apply_filters( 'bbc_hide_free_shipping_for_wholesale_enabled', true ) ) {
+			return $rates;
+		}
+
+		// 2. Only act for a logged-in front-end customer in a real Woo context.
+		if ( ! function_exists( 'WC' ) || is_admin() || ! is_user_logged_in() ) {
+			return $rates;
+		}
+
+		// 3. Wholesale role slugs that should NOT see Free Shipping (documented by display name).
+		//    Filterable so each environment / future role change can override without a code edit.
+		$hidden_roles = apply_filters( 'bbc_free_shipping_hidden_roles', array(
+			'b2bwhs_role_642389', // VIP wholesale local
+			'b2bwhs_role_637532', // Commission Base
+			'b2bwhs_role_632083', // Local Wholesale
+			'b2bwhs_role_631619', // Distributor (absent on some envs — harmless if missing)
+			'b2bwhs_role_631578', // Wholesale
+		) );
+		if ( empty( $hidden_roles ) ) {
+			return $rates;
+		}
+
+		// 4. Bail unless the current user holds one of the targeted wholesale roles.
+		$user = wp_get_current_user();
+		if ( ! $user || empty( $user->roles ) || ! array_intersect( (array) $user->roles, $hidden_roles ) ) {
+			return $rates;
+		}
+
+		// 5. Remove every Free Shipping rate from the package.
+		foreach ( $rates as $rate_id => $rate ) {
+			if ( isset( $rate->method_id ) && 'free_shipping' === $rate->method_id ) {
+				unset( $rates[ $rate_id ] );
+			}
+		}
+
+		return $rates;
+	}
+}
+add_filter( 'woocommerce_package_rates', 'bbc_hide_free_shipping_for_wholesale', 10, 2 );

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:       Blaze Commerce
  Author URI:   https://blazecommerce.io/
  Template:     blocksy
- Version:      1.1.14
+ Version:      1.1.46
  Text Domain:  blocksy-child
  License:      GNU General Public License v2 or later
  License URI:  https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary

Brings the **bbc opti site** child-theme working tree into the shared `blaze-blocksy` repo, syncing it from **v1.1.14 → v1.1.46** plus the site's uncommitted edits. Pulled from `ssh bbcopti@35.189.2.37:43227` via tar-over-SSH (the server's working tree was the source of truth — its git index was sparse/partial).

**20 files changed (+1080 / −120), no junk.**

### Highlights
- **Version:** `style.css` 1.1.14 → 1.1.46
- **Fixes:** PDP wishlist button height parity (CU-86exf034k), mobile-search background scroll-lock (CU-86exe005n)
- **WooCommerce PHP:** `inc/woocommerce.php`, `inc/enqueue.php`
- **New components:** `assets/css/components/woo-bogo.css`, `woo-cart.css`
- **CSS refinements:** checkout (order-summary, step-form, trust-badges), offcanvas, header, homepage, search-dropdown, wishlist-offcanvas, woo-archive, woo-cart, base
- **Client:** `clients/byronbay/byronbay.css` (+528)
- **Docs:** `CHANGELOG.md`, `docs/patterns/offcanvas.md`

### Sync method & exclusions
- Mechanism: `tar`-over-SSH (cygwin `rsync` fails on this Windows host)
- Excluded as junk: `.git`, `*.bak*`, `.claude/`, `node_modules/`, `*.log`, session files
- **Local `.github` CI workflows preserved** — the server had deleted its own copies, but those deletions were intentionally NOT mirrored so this repo keeps its CI
- No theme files were deleted (the v1.1.14 base files all still exist on the server)

### Verification
- ✅ `php -l` passes on both changed PHP files (`inc/enqueue.php`, `inc/woocommerce.php`)
- ✅ No `.bak`/`.claude`/log/session junk staged
- ⏸️ Playwright e2e not run (runs against a live site; not meaningful for a file-content sync — the diff is the review surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)