### PR TITLE
fix: button text colour follows Blocksy Customizer, not base.css #111111

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [button-text-color-from-customizer-2026-06-24] - 2026-06-24
+
+### Fixed
+- Button text colour is now controlled by the Blocksy Customizer (General > Buttons) site-wide. `assets/css/base.css` (migrated 2026-06-04 from Customizer Additional CSS) hard-set `--theme-button-text-initial-color: #111111` on the whole button selector group (`.button, .ct-button, .ct-button-ghost, [type=submit], .wp-element-button, .wp-block-button__link, ..., .ct-button-secondary-text`). Because the variable was declared on the button element, it overrode (a) Blocksy's `:root` Customizer value for solid (type-1) buttons and (b) Blocksy's own ghost (type-2) rule `--theme-button-text-initial-color: var(--theme-button-background-initial-color)`, forcing every button's text to `#111111`. Commented out that one line (kept `--theme-button-font-weight: 500`) so the cascade restores per-type Customizer behaviour: solid buttons take the `:root` Customizer text colour, ghost/outline buttons take the accent (background) colour, and `.ct-button-secondary-text` inherits the Customizer value. Reported on aworld-retheme.blz.au (Alternate Worlds). Theme 1.1.46 -> 1.1.47.
+
 ## [woo-cart-smartcoupons-guarded-enqueue-2026-06-03] - 2026-06-03
 
 ### Changed

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -204,5 +204,5 @@ body.page-id-645912 {
 /* Global button font-weight + text colour (migrated 2026-06-04 from Customizer Additional CSS). */
 .button, .ct-button, .added_to_cart, .ct-button-ghost, [type=submit], .wp-element-button, .wp-block-button__link, button.regform-button, button[class*=ajax], .woocommerce button.button, .woocommerce-message .showlogin, .woocommerce-message .restore-item, .forminator-ui[data-design=none] .forminator-button, .fluentform .ff-el-group button.ff-btn, .ct-button-secondary-text {
 	--theme-button-font-weight: 500;
-	--theme-button-text-initial-color: #111111;
+	/* --theme-button-text-initial-color: #111111; */ /* AW 2026-06-24: commented out so the Blocksy Customizer (General > Buttons) controls button text colour site-wide. Declaring it on the button element clobbered the :root Customizer value for solid buttons and Blocksy's ghost-button rule (ghost text = accent colour). Removing it restores per-type Customizer behaviour. */
 }

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:       Blaze Commerce
  Author URI:   https://blazecommerce.io/
  Template:     blocksy
- Version:      1.1.46
+ Version:      1.1.47
  Text Domain:  blocksy-child
  License:      GNU General Public License v2 or later
  License URI:  https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary
Comment out the hardcoded `--theme-button-text-initial-color: #111111` in `assets/css/base.css` so button text colour follows the **Blocksy Customizer (General > Buttons)** site-wide.

## Problem
`base.css` (migrated 2026-06-04 from Customizer Additional CSS) declared the variable on the whole button selector group. Because it's set **on the button element**, it beats Blocksy's `:root` Customizer value (solid buttons) and Blocksy's own ghost-button rule in the cascade — forcing every button's text to `#111111`. Reported on aworld-retheme.blz.au (Alternate Worlds).

## Fix
- Commented out the `#111111` line (kept `--theme-button-font-weight: 500`).
- Solid (type-1) buttons → `:root` Customizer text colour.
- Ghost / outline (type-2) buttons → accent (background) colour (Blocksy default restored).
- `.ct-button-secondary-text` → inherits the Customizer value.
- `style.css` Version 1.1.46 → 1.1.47; `CHANGELOG.md` entry added.

## Deploy
Per repo README (server is source of truth, no CI): after merge the file is `scp`'d to staging and caches purged. `base.css` is enqueued with `filemtime()` so `?ver` auto-busts.

## Test plan
- DevTools: `--theme-button-text-initial-color` on a `.ct-button` no longer resolves to `#111111`.
- Solid buttons (Log In, Search, Add to Cart, Place Order): white text on blue.
- Ghost / outline buttons: accent-colour text, still readable.
- `.ct-button-secondary-text` / `.added_to_cart` / AJAX buttons: correct.

## RESUME SESSION
```bash
claude --resume 89e63b81-4a6c-4640-8160-3469f564eb6a --permission-mode plan
```
