### PR TITLE
feat: Off-canvas Panel Icons Customizer control (minicart + wishlist drawers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [offcanvas-panel-icons-customizer-2026-06-25] - 2026-06-25
+
+### Added
+- New **"Off-canvas Panel Icons"** Customizer section (`inc/offcanvas-icons.php`, loaded as a core module in `inc/loader.php`) with two `WP_Customize_Media_Control` upload controls — **Minicart Drawer Icon** (`blocksy_child_minicart_panel_icon_id`) and **Wishlist Drawer Icon** (`blocksy_child_wishlist_panel_icon_id`). An admin can now replace the icon shown in the HEADING of the minicart drawer (`.ct-cart-panel-icon`) and the wishlist drawer (`.ct-wishlist-panel-icon`) from wp-admin, without touching code or a per-site overlay. Helper `blocksy_child_offcanvas_icon_markup()` inlines an uploaded SVG (injecting `ct-icon` so it inherits Blocksy sizing/colour via currentColor) or falls back to an `<img>`, returning '' when unset so the existing default SVG is kept (clients without an upload — e.g. byronbay — are unaffected). DELIBERATELY scoped to the off-canvas DRAWER icons only: the header-bar cart/wishlist icons remain controlled by Blocksy's native Customizer (Header > Cart / Wishlist > Icon Source: Custom) — they are separate icons by design (the header icon and the drawer heading icon can differ).
+
+### Changed
+- `inc/woocommerce.php` (`bc_filter_cart_panel_heading`) and `inc/wishlist-offcanvas.php` (`blocksy_child_render_wishlist_panel`) now call `blocksy_child_offcanvas_icon_markup()` for their drawer-heading icon, overriding the hard-coded default ONLY when an admin has uploaded one. Requested for Alternate Worlds (aworld-retheme.blz.au), ClickUp 86ey26h27. Theme 1.1.47 -> 1.1.48.
+
 ## [button-text-color-from-customizer-2026-06-24] - 2026-06-24
 
 ### Fixed

--- a/inc/loader.php
+++ b/inc/loader.php
@@ -67,6 +67,7 @@ blocksy_child_load_module( 'inc/helpers.php' );
 blocksy_child_load_module( 'inc/enqueue.php' );
 blocksy_child_load_module( 'inc/hooks.php' );
 blocksy_child_load_module( 'inc/icons.php' );
+blocksy_child_load_module( 'inc/offcanvas-icons.php' );
 blocksy_child_load_module( 'inc/carousel.php' );
 
 // --- Client Modules (load BEFORE WooCommerce modules so feature flags are available) ---

--- a/inc/offcanvas-icons.php
+++ b/inc/offcanvas-icons.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Off-canvas Panel Icons — Customizer image/SVG control for the drawer headings.
+ *
+ * Adds an "Off-canvas Panel Icons" Customizer section with two media-upload
+ * controls so an admin can swap the icon shown in the heading of the minicart
+ * drawer and the wishlist drawer — WITHOUT touching code or a /custom overlay.
+ *
+ * Scope: OFF-CANVAS PANEL ICONS ONLY. These are deliberately INDEPENDENT of the
+ * header trigger icons (the little cart/wishlist icons in the header bar), which
+ * are already configurable via Blocksy's native Customizer
+ * (Header > Cart / Wishlist > Icon Source: Custom). The drawer heading icon and
+ * the header icon can be different by design, so each is controlled separately.
+ *
+ * What this drives (the previously hard-coded drawer icons):
+ *   - minicart drawer heading icon  → inc/woocommerce.php (`.ct-cart-panel-icon`)
+ *   - wishlist drawer heading icon  → inc/wishlist-offcanvas.php (`.ct-wishlist-panel-icon`)
+ *
+ * Storage: attachment ID in wp_options (`blocksy_child_minicart_panel_icon_id`,
+ * `blocksy_child_wishlist_panel_icon_id`). Empty = keep the theme default (so
+ * clients that don't set one — e.g. byronbay — are unaffected).
+ *
+ * @package Blocksy_Child
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Map of supported off-canvas icons => the wp_options key holding the attachment ID.
+ *
+ * @return array<string,string>
+ */
+function blocksy_child_offcanvas_icon_options() {
+	return array(
+		'minicart' => 'blocksy_child_minicart_panel_icon_id',
+		'wishlist' => 'blocksy_child_wishlist_panel_icon_id',
+	);
+}
+
+/**
+ * Attachment ID configured for a given off-canvas icon ('minicart' | 'wishlist').
+ *
+ * @param string $which Icon key.
+ * @return int Attachment ID, or 0 when unset.
+ */
+function blocksy_child_offcanvas_icon_id( $which ) {
+	$options = blocksy_child_offcanvas_icon_options();
+
+	if ( ! isset( $options[ $which ] ) ) {
+		return 0;
+	}
+
+	return (int) get_option( $options[ $which ], 0 );
+}
+
+/**
+ * Inline markup for a configured off-canvas panel icon, or '' when none is set.
+ *
+ * SVG attachments are inlined (so they inherit Blocksy's `ct-icon` sizing/color
+ * via `currentColor`, exactly like the stock icons). Raster attachments fall
+ * back to an <img>. Returns '' when no icon is configured — callers then keep
+ * their own default markup.
+ *
+ * @param string $which       Icon key ('minicart' | 'wishlist').
+ * @param string $extra_class Extra class(es) to add alongside `ct-icon`.
+ * @return string Icon HTML, or '' when unset/unreadable.
+ */
+function blocksy_child_offcanvas_icon_markup( $which, $extra_class = '' ) {
+	$id = blocksy_child_offcanvas_icon_id( $which );
+
+	if ( ! $id ) {
+		return '';
+	}
+
+	$classes = trim( 'ct-icon ' . $extra_class );
+	$file    = get_attached_file( $id );
+	$mime    = get_post_mime_type( $id );
+
+	if ( $file && 'image/svg+xml' === $mime && is_readable( $file ) ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local theme asset, not a remote fetch.
+		$svg = file_get_contents( $file );
+
+		if ( ! $svg ) {
+			return '';
+		}
+
+		// Strip XML prolog / doctype / comments so the SVG inlines cleanly.
+		$svg = preg_replace( '/<\?xml.*?\?>/is', '', $svg );
+		$svg = preg_replace( '/<!DOCTYPE.*?>/is', '', $svg );
+		$svg = preg_replace( '/<!--.*?-->/is', '', $svg );
+		$svg = trim( (string) $svg );
+
+		if ( '' === $svg || false === stripos( $svg, '<svg' ) ) {
+			return '';
+		}
+
+		// Merge our classes into the root <svg> (prepend if it already has class=).
+		if ( preg_match( '/<svg\b[^>]*\bclass="/i', $svg ) ) {
+			$svg = preg_replace( '/(<svg\b[^>]*\bclass=")/i', '${1}' . esc_attr( $classes ) . ' ', $svg, 1 );
+		} else {
+			$svg = preg_replace( '/<svg\b/i', '<svg class="' . esc_attr( $classes ) . '"', $svg, 1 );
+		}
+
+		return (string) $svg;
+	}
+
+	$url = wp_get_attachment_image_url( $id, 'full' );
+
+	if ( ! $url ) {
+		return '';
+	}
+
+	return '<img class="' . esc_attr( $classes ) . '" src="' . esc_url( $url ) . '" alt="" />';
+}
+
+/**
+ * Register the "Off-canvas Panel Icons" Customizer section + media controls.
+ *
+ * Stored as `option` (site-wide), sanitized to an attachment ID. The native
+ * WP_Customize_Media_Control gives the same upload UX as Blocksy's custom-icon
+ * field. Intentionally separate from the header trigger icons.
+ *
+ * @param WP_Customize_Manager $wp_customize Customizer manager.
+ * @return void
+ */
+function blocksy_child_register_offcanvas_icon_controls( $wp_customize ) {
+	$wp_customize->add_section(
+		'blocksy_child_offcanvas_icons',
+		array(
+			'title'       => __( 'Off-canvas Panel Icons (Child Theme)', 'blocksy-child' ),
+			'priority'    => 160,
+			'description' => __( 'Upload a custom image/SVG for the icon shown in the heading of the minicart drawer and the wishlist drawer. These are separate from the header bar icons (set those under Header > Cart / Wishlist). Leave empty to keep the theme default.', 'blocksy-child' ),
+		)
+	);
+
+	$controls = array(
+		'minicart' => __( 'Minicart Drawer Icon', 'blocksy-child' ),
+		'wishlist' => __( 'Wishlist Drawer Icon', 'blocksy-child' ),
+	);
+
+	$options = blocksy_child_offcanvas_icon_options();
+
+	foreach ( $controls as $key => $label ) {
+		$setting = $options[ $key ];
+
+		$wp_customize->add_setting(
+			$setting,
+			array(
+				'type'              => 'option',
+				'capability'        => 'manage_options',
+				'default'           => '',
+				'sanitize_callback' => 'absint',
+			)
+		);
+
+		$wp_customize->add_control(
+			new WP_Customize_Media_Control(
+				$wp_customize,
+				$setting,
+				array(
+					'label'       => $label,
+					'description' => __( 'SVG recommended (square viewBox, ~24×24). Falls back to the theme default when empty.', 'blocksy-child' ),
+					'section'     => 'blocksy_child_offcanvas_icons',
+					'mime_type'   => 'image',
+				)
+			)
+		);
+	}
+}
+add_action( 'customize_register', 'blocksy_child_register_offcanvas_icon_controls' );

--- a/inc/wishlist-offcanvas.php
+++ b/inc/wishlist-offcanvas.php
@@ -245,8 +245,18 @@ function blocksy_child_render_wishlist_panel() {
 
 	$close_icon = '<svg class="ct-icon" width="12" height="12" viewBox="0 0 15 15"><path d="M1 15a1 1 0 01-.71-.29 1 1 0 010-1.41l5.8-5.8-5.8-5.8A1 1 0 011.7.29l5.8 5.8 5.8-5.8a1 1 0 011.41 1.41l-5.8 5.8 5.8 5.8a1 1 0 01-1.41 1.41l-5.8-5.8-5.8 5.8A1 1 0 011 15z"/></svg>';
 
-	// Wishlist heart icon — same SVG as the header wishlist icon.
+	// Wishlist heart icon — same SVG as the header wishlist icon. This is the
+	// DEFAULT; the "Off-canvas Panel Icons" Customizer control
+	// (inc/offcanvas-icons.php) overrides it when an admin uploads a drawer icon.
 	$heart_icon = '<svg class="ct-icon ct-wishlist-panel-icon" width="15" height="15" viewBox="0 0 15 15"><path d="M7.5,13.9l-0.4-0.3c-0.2-0.2-4.6-3.5-5.8-4.8C0.4,7.7-0.1,6.4,0,5.1c0.1-1.2,0.7-2.2,1.6-3c0.9-0.8,2.3-1,3.6-0.8C6.1,1.5,6.9,2,7.5,2.6c0.6-0.6,1.4-1.1,2.4-1.3c1.3-0.2,2.6,0,3.5,0.8l0,0c0.9,0.7,1.5,1.8,1.6,3c0.1,1.3-0.3,2.6-1.3,3.7c-1.2,1.4-5.6,4.7-5.7,4.8L7.5,13.9z"/></svg>';
+
+	if ( function_exists( 'blocksy_child_offcanvas_icon_markup' ) ) {
+		$custom_heart = blocksy_child_offcanvas_icon_markup( 'wishlist', 'ct-wishlist-panel-icon' );
+
+		if ( '' !== $custom_heart ) {
+			$heart_icon = $custom_heart;
+		}
+	}
 
 	// Render suggested products (server-side, same as mini cart).
 	$suggested_html = blocksy_child_render_wishlist_suggested();

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -414,10 +414,19 @@ function bc_filter_cart_panel_heading( $translation, $text, $domain ) {
 
 	$count = ( function_exists( 'WC' ) && WC()->cart ) ? (int) WC()->cart->get_cart_contents_count() : 0;
 
-	// Same custom shopping-bag icon used by the header cart trigger
-	// (uploaded via Blocksy custom-icon feature). Solid-fill, not stroked.
-	// fill=currentColor so the icon inherits the heading text color.
+	// Same custom shopping-bag icon used by the header cart trigger. Solid-fill,
+	// not stroked. fill=currentColor so the icon inherits the heading text color.
+	// This is the DEFAULT; the "Off-canvas Panel Icons" Customizer control
+	// (inc/offcanvas-icons.php) overrides it when an admin uploads a drawer icon.
 	$icon = '<svg class="ct-icon ct-cart-panel-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false"><path d="M14.6248 5.5C14.6248 3.84315 13.2816 2.5 11.6248 2.5C9.96813 2.50026 8.62476 3.84331 8.62476 5.5V6.25H14.6248V5.5ZM5.13844 7.75C4.94653 7.75 4.78548 7.89508 4.76539 8.08594L3.50172 20.0859C3.47855 20.3072 3.65226 20.4999 3.87476 20.5H19.3757C19.5982 20.4999 19.772 20.3072 19.7488 20.0859L18.4851 8.08594C18.465 7.89508 18.304 7.75 18.1121 7.75H16.1248V9.16211C16.3549 9.3681 16.4998 9.66684 16.4998 10C16.4998 10.6213 15.9961 11.125 15.3748 11.125C14.7537 11.1247 14.2498 10.6212 14.2498 10C14.2498 9.66733 14.3952 9.36905 14.6248 9.16309V7.75H8.62476V9.16211C8.85489 9.3681 8.99976 9.66684 8.99976 10C8.99976 10.6213 8.49608 11.125 7.87476 11.125C7.25367 11.1247 6.74976 10.6212 6.74976 10C6.74976 9.66733 6.89523 9.36905 7.12476 9.16309V7.75H5.13844ZM16.1248 6.25H18.1121C19.0716 6.25 19.8769 6.97444 19.9773 7.92871L21.24 19.9287C21.3565 21.0357 20.4889 21.9999 19.3757 22H3.87476C2.76163 21.9999 1.89398 21.0357 2.01051 19.9287L3.2732 7.92871C3.37365 6.97444 4.17889 6.25 5.13844 6.25H7.12476V5.5C7.12476 3.01488 9.13971 1.00026 11.6248 1C14.11 1 16.1248 3.01472 16.1248 5.5V6.25Z" fill="currentColor"/></svg>';
+
+	if ( function_exists( 'blocksy_child_offcanvas_icon_markup' ) ) {
+		$custom = blocksy_child_offcanvas_icon_markup( 'minicart', 'ct-cart-panel-icon' );
+
+		if ( '' !== $custom ) {
+			$icon = $custom;
+		}
+	}
 
 	return $icon
 		. ' <span class="ct-cart-panel-title">' . esc_html__( 'Your bag', 'blocksy-child' ) . '</span>'

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:       Blaze Commerce
  Author URI:   https://blazecommerce.io/
  Template:     blocksy
- Version:      1.1.47
+ Version:      1.1.48
  Text Domain:  blocksy-child
  License:      GNU General Public License v2 or later
  License URI:  https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary
Adds an **Off-canvas Panel Icons** Customizer control so an admin can replace the icon shown in the **heading of the minicart drawer** and the **wishlist drawer** from wp-admin — no code or per-site overlay needed.

Scoped to the off-canvas **drawer** icons ONLY. The header-bar cart/wishlist icons stay controlled by Blocksy's native Customizer (Header > Cart / Wishlist > Icon Source: Custom) — they are separate icons by design (the header icon and the drawer heading icon can differ).

## Changes
- **New** `inc/offcanvas-icons.php` (core module, loaded via `inc/loader.php`): Customizer section "Off-canvas Panel Icons" with two `WP_Customize_Media_Control` uploads — Minicart Drawer Icon (`blocksy_child_minicart_panel_icon_id`) and Wishlist Drawer Icon (`blocksy_child_wishlist_panel_icon_id`). Helper `blocksy_child_offcanvas_icon_markup()` inlines an uploaded SVG (injects `ct-icon` for sizing/colour via currentColor) or falls back to `<img>`; returns '' when unset so the default SVG is kept.
- `inc/woocommerce.php` (`bc_filter_cart_panel_heading`) + `inc/wishlist-offcanvas.php` (`blocksy_child_render_wishlist_panel`): read the helper, overriding the hard-coded default only when an admin uploads one.
- `style.css` 1.1.47 → 1.1.48; CHANGELOG.

## Why
The drawer heading icons (`.ct-cart-panel-icon`, `.ct-wishlist-panel-icon`) were hard-coded with no wp-admin control. The header-bar icons already follow Blocksy's native Customizer (PR #122), so this fills the remaining gap for the **drawer** icons, as a separate control.

## Test plan
- [x] PHP lint clean (LocalWP php 8.3) on all changed files
- [x] Functional test (real WP/Blocksy via `eval-file`): helper inlines SVG + `ct-icon` + panel class + `currentColor`; minicart + wishlist drawer helpers resolve; **header trigger filters untouched** (separation verified); empty → '' fallback. All PASS.
- [ ] Staging visual: upload a drawer SVG in Customizer → Off-canvas Panel Icons; open minicart + wishlist drawers; confirm heading icon updates; default unchanged when empty.
- No regression for other clients (byronbay): default kept when no upload set.

**ClickUp:** https://app.clickup.com/t/86ey26h27

## Resume
```bash
cd /Users/alanregaya/Documents/.work/.blz && claude --resume beed750d-ccc9-4b35-a689-9a1f76340d70
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
