### PR TITLE
feat(wishlist): per-site card-grid layout for the off-canvas drawer (86ey0r46n)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [wishlist-card-grid-layout-2026-06-30] - 2026-06-30
+
+### Added
+- New per-site filter **`blocksy_child_wishlist_card_layout`** (default `false`) that switches the off-canvas wishlist drawer to the Figma "card grid" layout. Helper `blocksy_child_wishlist_uses_cards()` is the single gate; `blocksy_child_wishlist_image_size()` returns `woocommerce_single` (full portrait cover) when on vs the square `woocommerce_gallery_thumbnail` when off. New `blocksy_child_render_wishlist_categories()` renders an empty-state "You May Also Like" 2-col category grid (top-level product categories that have a featured term image — live names + counts; `blocksy_child_wishlist_category_ids`-filterable) and `blocksy_child_wishlist_current_ids()` shares the server-side wishlist id lookup. Requested for Alternate Worlds (aworld-retheme.blz.au), ClickUp 86ey0r46n.
+
+### Changed
+- `inc/wishlist-offcanvas.php` — when the filter is on: the preload + AJAX endpoint use the portrait image size; `bcWishlistData` carries a `cardLayout` flag; the panel shell adds a `ct-wishlist-cards` class, an initial `ct-wishlist-state-empty|filled` class (server-computed, no flash), and the category-grid region.
+- `assets/js/wishlist-offcanvas.js` — when on: items render as a 2-col card grid (`ct-wishlist-items--cards`) with a "Remove" text control instead of the trash icon; `setPanelEmptyState()` keeps the empty/filled state class in sync (toggles the category grid vs the suggested carousel). The card flag is read at render time (`usesCards()`) because the preload `<script>` prints after this footer script.
+- **Every change is gated behind the filter.** With it off (Byron Bay and all other sites) the drawer renders byte-for-byte as before — the only additions are an inert `cardLayout:false` data field and unstyled state classes. Theme 1.1.48 -> 1.1.49.
+
 ## [offcanvas-panel-icons-customizer-2026-06-25] - 2026-06-25
 
 ### Added
@@ -974,10 +984,7 @@ M  style.css                                    (Version 1.1.5 → 1.1.6)
 
 ## [86exf034k] - 2026-05-05
 ### Fixed
-- `assets/css/components/woo-single.css` (PDP #1 + B4): Replace `aspect-ratio:1/1` with
-  `align-self:stretch` + `height:auto` so the wishlist button height tracks the rendered
-  ATC flex-row height at all breakpoints instead of locking to `--theme-button-min-height`
-  token. Adds `box-sizing:border-box`. Applies to standard product and bundle product selectors.
+- `assets/css/components/woo-single.css` (PDP #1 + B4): Replace `aspect-ratio:1/1` with `align-self:stretch` + `height:auto` so the wishlist button height tracks the rendered ATC flex-row height at all breakpoints instead of locking to `--theme-button-min-height` token. Adds `box-sizing:border-box`. Applies to standard product and bundle product selectors.
 
 ## [86exe005n] - 2026-05-05
 ### Fixed
@@ -1122,11 +1129,9 @@ M  style.css                                    (Version 1.1.5 → 1.1.6)
 ### Fixed
 - Mini cart Shipping row now correctly reverts from "Free" to "Calculated at checkout" when items are removed and the cart drops back below the free-shipping threshold. It also now agrees with Blocksy's progress-bar banner in every cart state (above, below, exactly-at the threshold).
 
-### Why
-QA flagged a state-machine bug: after qualifying for free shipping then removing items, the Shipping row stayed pinned at "Free" while the Blocksy banner correctly showed "Add $X more". Two contradictions in one drawer was worse than the original problem we set out to fix.
+### Why QA flagged a state-machine bug: after qualifying for free shipping then removing items, the Shipping row stayed pinned at "Free" while the Blocksy banner correctly showed "Add $X more". Two contradictions in one drawer was worse than the original problem we set out to fix.
 
-### Root cause
-Two mismatches at once:
+### Root cause Two mismatches at once:
 1. The previous helper matched any `cost === 0` rate as "Free". On this site that included Local Pickup (Australia zone) — so even an empty-of-free-shipping cart returned "Free" because Local Pickup is always $0.
 2. The previous helper read WC's zone `min_amount` (Australia zone = $75), but Blocksy reads from `theme_mod woo_count_progress_amount` (set to $100 on this site). So at $88 cart, WC said free shipping was available but Blocksy said "Add $12 more" — and the row sided with WC, contradicting the banner directly above it.
 
@@ -1146,22 +1151,19 @@ Screenshots: `cu-86exbd8gx-shipping-below-threshold-final.png`, `cu-86exbd8gx-sh
 ### Backups
 - `inc/woocommerce.php.bak-20260428-shipping-fix`
 
-### Note for future devs
-If the Customizer setting "Cart > Shipping Progress > Count Method" is ever switched from `custom` to `woo`, this function automatically picks up the change (it reads the same theme mod Blocksy reads). No code change needed.
+### Note for future devs If the Customizer setting "Cart > Shipping Progress > Count Method" is ever switched from `custom` to `woo`, this function automatically picks up the change (it reads the same theme mod Blocksy reads). No code change needed.
 
 ## [86exbd8gx-followup] - 2026-04-29
 ### Fixed
 - Mini cart Shipping row now shows "Free" when the cart qualifies for free shipping (matches Blocksy's progress-bar messaging "Congratulations! You got free shipping 🎉"). Previously hard-coded to "Calculated at checkout" which contradicted the green bar.
 
-### Why
-QA flagged the inconsistency: the Blocksy free-shipping progress bar declared the customer had earned free shipping, but our Shipping row directly below said "Calculated at checkout". Customers would either dismiss the green bar as marketing noise or assume the rate was about to change. Showing "Free" in both spots removes the cognitive dissonance.
+### Why QA flagged the inconsistency: the Blocksy free-shipping progress bar declared the customer had earned free shipping, but our Shipping row directly below said "Calculated at checkout". Customers would either dismiss the green bar as marketing noise or assume the rate was about to change. Showing "Free" in both spots removes the cognitive dissonance.
 
 ### Implementation
 - `inc/woocommerce.php` — added `bc_mini_cart_shipping_value()` helper. Calls `WC()->shipping()->calculate_shipping( $cart->get_shipping_packages() )` to recalculate rates for the current cart, then walks `WC()->shipping()->get_packages()` looking for any rate where `method_id === 'free_shipping'` OR `cost === 0`. Returns "Free" if found, otherwise falls back to "Calculated at checkout".
 - `bc_render_mini_cart_totals_section()` now uses this helper for the Shipping row value.
 
-### Performance note
-We force a shipping calculation per mini cart fragment render. WC caches the result in the cart session so subsequent fragment fetches in the same request don't recompute. Still — if a future site has a slow shipping plugin (the AusPost plugin used here is one example), this adds latency to every cart-fragments AJAX call. Watch the slow-query log if you start seeing wc-ajax timeouts.
+### Performance note We force a shipping calculation per mini cart fragment render. WC caches the result in the cart session so subsequent fragment fetches in the same request don't recompute. Still — if a future site has a slow shipping plugin (the AusPost plugin used here is one example), this adds latency to every cart-fragments AJAX call. Watch the slow-query log if you start seeing wc-ajax timeouts.
 
 ### Backups
 - `inc/woocommerce.php.bak-20260429-002000`
@@ -1170,19 +1172,16 @@ We force a shipping calculation per mini cart fragment render. WC caches the res
 ### Changed
 - Suggested Products carousel in mini cart + wishlist drawers now feels more compact: title clamped to 2 lines (was wrapping 3+ on long names), title 13px / price 12px, tighter module-title spacing. Image keeps its native full-column-width square layout — `object-fit: contain` so source product photos never crop top/bottom.
 
-### Why
-QA flagged the section as visually too large making the drawer bottom-heavy. Root cause was long product titles wrapping 3+ lines (e.g. "All Reed Diffuser Refills 130mls with New Reed Sticks") not the image itself. Fixing the title with `-webkit-line-clamp: 2` shaved ~14px per card; the smaller fonts + tighter heading margin removed another ~10–15px. Image stays full-width square per Figma 684:85959 reference.
+### Why QA flagged the section as visually too large making the drawer bottom-heavy. Root cause was long product titles wrapping 3+ lines (e.g. "All Reed Diffuser Refills 130mls with New Reed Sticks") not the image itself. Fixing the title with `-webkit-line-clamp: 2` shaved ~14px per card; the smaller fonts + tighter heading margin removed another ~10–15px. Image stays full-width square per Figma 684:85959 reference.
 
 ### Iterations during this fix (for posterity — explains the diff if you bisect)
 1. **First attempt:** capped image at `max-height: 140px` with `object-fit: cover`. This visibly cropped top/bottom of square candle photos (lid + holder cut off). Reverted.
 2. **Second attempt:** capped image at `max-width: 140px` with `object-fit: contain`. Image stayed un-cropped but became smaller-than-card-width with whitespace, which made cards feel inconsistent with native Blocksy layout. Reverted.
 3. **Final (this commit):** drop both width and height caps. Keep full-column-width square via `aspect-ratio: 1/1`. Use `object-fit: contain` so any non-square source photo never crops. Visual-weight reduction comes purely from title clamp + smaller fonts.
 
-### Selectors
-Both drawers (`#woo-cart-panel`, `#woo-wishlist-panel`) and both render paths covered in one block — `[class*="ct-suggested-products"]` matches Blocksy's native `.ct-suggested-products--mini-cart` (state 1) AND our renamed `bc-*-suggested-grid ct-suggested-products` two-class wrappers (states 2–7) — see `docs/patterns/drawer-suggested-products.md` for the 7-state matrix.
+### Selectors Both drawers (`#woo-cart-panel`, `#woo-wishlist-panel`) and both render paths covered in one block — `[class*="ct-suggested-products"]` matches Blocksy's native `.ct-suggested-products--mini-cart` (state 1) AND our renamed `bc-*-suggested-grid ct-suggested-products` two-class wrappers (states 2–7) — see `docs/patterns/drawer-suggested-products.md` for the 7-state matrix.
 
-### Verified at 320 / 375 / 768 / 1400 / 1440
-Card height dropped from 295 → 281 (≈5%), but visually feels more balanced because the title block is the same height regardless of product name length. No image cropping in any state. Screenshots: `cu-86exbd8kg-{minicart,wishlist}-final-*.png` in repo root.
+### Verified at 320 / 375 / 768 / 1400 / 1440 Card height dropped from 295 → 281 (≈5%), but visually feels more balanced because the title block is the same height regardless of product name length. No image cropping in any state. Screenshots: `cu-86exbd8kg-{minicart,wishlist}-final-*.png` in repo root.
 
 ### Backups
 - `assets/css/components/offcanvas.css.bak-20260429-001500`
@@ -1195,8 +1194,7 @@ Card height dropped from 295 → 281 (≈5%), but visually feels more balanced b
 - `inc/woocommerce.php` — appended `bc_render_mini_cart_totals_section()` hooked to `woocommerce_widget_shopping_cart_before_buttons` (priority 30, runs after Blocksy's shipping progress bar at priority 10–20). Renders only when cart is non-empty. Toggleable via `BC_FEATURE_MINI_CART_TOTALS` (default true) so a client PHP can disable.
 - `assets/css/components/offcanvas.css` — appended styling for `.bc-mini-cart-totals` block: 12px top padding + dashed border-top, flex space-between rows, Order Total in 16px semibold with its own divider above for visual prominence.
 
-### Why
-Native Blocksy + WooCommerce mini cart shows only the Subtotal row before the Checkout button. Per Figma 684:85959 reference (parent off-canvas spec) and the Austin Natural Mattress reference layout, the drawer needs a clearer breakdown so customers see "Shipping: Calculated at checkout" + "Order Total" before clicking Checkout. Reduces surprise-cost abandonment per Baymard's checkout-transparency research.
+### Why Native Blocksy + WooCommerce mini cart shows only the Subtotal row before the Checkout button. Per Figma 684:85959 reference (parent off-canvas spec) and the Austin Natural Mattress reference layout, the drawer needs a clearer breakdown so customers see "Shipping: Calculated at checkout" + "Order Total" before clicking Checkout. Reduces surprise-cost abandonment per Baymard's checkout-transparency research.
 
 ### Backups
 - `inc/woocommerce.php.bak-20260428-234500`
@@ -1205,14 +1203,12 @@ Native Blocksy + WooCommerce mini cart shows only the Subtotal row before the Ch
 ### Fixed
 - Mini cart Checkout button now spans the full content width of the drawer at all breakpoints (320 / 375 / 768 / 1440 / 2560).
 
-### Why
-Native Blocksy ships `.woocommerce-mini-cart__buttons` with `padding: 0 24px 24px` AND `display: flex; gap: 8px`. The wrap already sits inside `.ct-panel-content-inner` which has its own 24px (mobile: 16px) horizontal padding — double padding made the button render at ~80% drawer width.
+### Why Native Blocksy ships `.woocommerce-mini-cart__buttons` with `padding: 0 24px 24px` AND `display: flex; gap: 8px`. The wrap already sits inside `.ct-panel-content-inner` which has its own 24px (mobile: 16px) horizontal padding — double padding made the button render at ~80% drawer width.
 
 ### Fix
 - `assets/css/components/offcanvas.css` — appended a mini-cart-scoped block that removes the wrap's horizontal padding, switches the wrap to vertical stack with 8px gap (so View Cart + Checkout each get full width when both visible), and forces `width: 100%` on the buttons. Selectors target both `#woo-cart-panel` and `.woocommerce-mini-cart` so the rule survives cart-fragments AJAX re-renders.
 
-### Verified
-Button width at each breakpoint matches drawer content area exactly (inner_width − 2 × content_padding):
+### Verified Button width at each breakpoint matches drawer content area exactly (inner_width − 2 × content_padding):
 - 320 → 288 inner / 256 btn (16px padding)
 - 375 → 338 inner / 306 btn (16px padding)
 - 1440 → 500 inner / 452 btn (24px padding)
@@ -1234,8 +1230,7 @@ Button width at each breakpoint matches drawer content area exactly (inner_width
 ### Backups
 - `assets/js/wishlist-offcanvas.js.bak-20260428-211800`
 
-### Verified
-Empty wishlist drawer state — clicked next arrow, items slid by `-468px` (one full page in 2-column boxed mode); clicked dim backdrop, panel closed with `active` class removed. Same flow works for guest and logged-in empty states.
+### Verified Empty wishlist drawer state — clicked next arrow, items slid by `-468px` (one full page in 2-column boxed mode); clicked dim backdrop, panel closed with `active` class removed. Same flow works for guest and logged-in empty states.
 
 ## [86exbd883-v4] - 2026-04-28
 ### Fixed
@@ -1251,15 +1246,13 @@ Empty wishlist drawer state — clicked next arrow, items slid by `-468px` (one 
   - Mirrors the `.ct-cart-actions > .quantity[data-type="type-2"]` horizontal stepper rules under `.ct-product-actions > .quantity[data-type="type-2"]`.
   - Adds typographic `−` / `+` glyphs on the buttons.
 
-### Note for future
-The horizontal stepper rules are now in TWO places: `clients/byronbay/byronbay.css` (cart page, `.ct-cart-actions` scope) and `assets/css/components/offcanvas.css` (mini cart, `.ct-product-actions` scope). When Blocksy updates its qty stepper or the customizer setting changes, both blocks must stay in sync. Documented as TODO in code comment.
+### Note for future The horizontal stepper rules are now in TWO places: `clients/byronbay/byronbay.css` (cart page, `.ct-cart-actions` scope) and `assets/css/components/offcanvas.css` (mini cart, `.ct-product-actions` scope). When Blocksy updates its qty stepper or the customizer setting changes, both blocks must stay in sync. Documented as TODO in code comment.
 
 ## [86exbd883-v3] - 2026-04-28
 ### Fixed
 - Suggested Products prev/next arrows now work on all 7 drawer states. Click `<` / `>` slides the carousel exactly like Blocksy native cart-with-items rendering (matrix transform `-468px` per click in 2-column boxed mode).
 
-### Why
-Blocksy's `flexy.js` (theme bundle) binds prev/next click handlers via:
+### Why Blocksy's `flexy.js` (theme bundle) binds prev/next click handlers via:
 ```js
 const maybeSuggested = sliderEl.closest('[class*="ct-suggested-products"]');
 if (maybeSuggested) {
@@ -1269,8 +1262,7 @@ if (maybeSuggested) {
 ```
 Our previous wrapper class `bc-minicart-suggested-grid` did NOT contain the substring `ct-suggested-products`, so flexy couldn't find the arrows from within the slider. Items rendered correctly (because the CSS shim mirrored the column rules) but arrows were inert (decoration-only).
 
-### Fix
-`inc/helpers.php` — the str_replace now produces `bc-minicart-suggested-grid ct-suggested-products` (and `bc-wishlist-suggested-grid ct-suggested-products` for the wishlist drawer). Two classes on one element:
+### Fix `inc/helpers.php` — the str_replace now produces `bc-minicart-suggested-grid ct-suggested-products` (and `bc-wishlist-suggested-grid ct-suggested-products` for the wishlist drawer). Two classes on one element:
 - `bc-minicart-suggested-grid` — our cart-fragments-safe namespace
 - `ct-suggested-products` — Blocksy's substring without the `--mini-cart` suffix
 
@@ -1279,26 +1271,22 @@ Our previous wrapper class `bc-minicart-suggested-grid` did NOT contain the subs
 - Flexy.js arrow lookup: `closest('[class*="ct-suggested-products"]')` — substring match, our wrapper has `ct-suggested-products` so it MATCHES.
 - Customizer typography rules `[class*="ct-suggested-products"] .ct-module-title` etc — substring match, also applies. (LAYER 8 v1/v2 shim rules are still kept as belt-and-suspenders, but most are now redundant.)
 
-### Verified
-Empty mini cart state, hover next-arrow → click — items slid `956,1190,1424,1658` → `722,956,1190,1424`. Same translate as native cart-with-items state.
+### Verified Empty mini cart state, hover next-arrow → click — items slid `956,1190,1424,1658` → `722,956,1190,1424`. Same translate as native cart-with-items state.
 
-### Bonus discovery
-Flexy lazy-mounts on first `mouseover`; programmatic `.click()` without prior hover does nothing. Real users hover before clicking, so no UX impact — but the wishlist sentinel JS test was passing arrows but actually testing `mouseover` separately. Documented in code architecture memory.
+### Bonus discovery Flexy lazy-mounts on first `mouseover`; programmatic `.click()` without prior hover does nothing. Real users hover before clicking, so no UX impact — but the wishlist sentinel JS test was passing arrows but actually testing `mouseover` separately. Documented in code architecture memory.
 
 ## [86exbd883-v2] - 2026-04-28
 ### Fixed
 - Suggested Products heading and product card layout now match Blocksy native (Image #8) byte-for-byte. Heading is "SUGGESTED PRODUCTS" UPPERCASE 12px 700 with arrows on the right of the same row; product titles and prices stack vertically inside each card (no more "Reed Sticks$33.00" run-together inline display).
 
-### Why this was needed
-Image #7 vs Image #8 audit (2026-04-28 evening) found three Blocksy CSS rules that the previous LAYER 8 v1 shim missed:
+### Why this was needed Image #7 vs Image #8 audit (2026-04-28 evening) found three Blocksy CSS rules that the previous LAYER 8 v1 shim missed:
 - `[class*="ct-suggested-products"] .ct-module-title { display: flex; justify-content: space-between; ... font-size: 12px; font-weight: 700; text-transform: uppercase; }` — the heading row layout
 - `[class*="ct-suggested-products"] section { display: flex; flex-direction: column; align-items: flex-start; }` — the unnamed `<section>` wrapper that stacks title + price vertically
 - `[class*="ct-suggested-products"] [data-products="block"] .ct-media-container { margin-bottom: 15px; }` — image bottom spacing
 
 All three target `[class*="ct-suggested-products"]` (substring match) which our renamed `bc-minicart-suggested-grid` / `bc-wishlist-suggested-grid` doesn't match. LAYER 8 v2 mirrors them under our renamed wrappers.
 
-### Verified
-Computed CSS values for renamed empty-cart rendering now match native cart-with-item rendering exactly (.ct-module-title display: flex / justifyContent: space-between / textTransform: uppercase / fontSize: 12px / fontWeight: 700 / marginBottom: 15px; flexy-item > section display: flex / flexDirection: column; .ct-product-title display: block; .price display: block).
+### Verified Computed CSS values for renamed empty-cart rendering now match native cart-with-item rendering exactly (.ct-module-title display: flex / justifyContent: space-between / textTransform: uppercase / fontSize: 12px / fontWeight: 700 / marginBottom: 15px; flexy-item > section display: flex / flexDirection: column; .ct-product-title display: block; .price display: block).
 
 ### Changed
 - `assets/css/components/wishlist-offcanvas.css` — appended LAYER 8 v2 block (3 new rules above) to the existing LAYER 8 shim.
@@ -1313,11 +1301,9 @@ Computed CSS values for renamed empty-cart rendering now match native cart-with-
 - `assets/js/wishlist-flexy-sentinel.js` — reframed header comment as LAYER 7 runtime visibility sentinel (post-Blocksy-update QA tool). Previous comment claimed "flexy JS doesn't initialize inside our custom panel" — that was wrong; `flexy.min.js` does auto-init via DOMContentLoaded. Implementation untouched.
 - `assets/css/components/wishlist-offcanvas.css` — appended LAYER 8 column/typography shim. Mirrors Blocksy's customizer-driven CSS (`--grid-columns-width: calc(100% / 2)`, typography vars, image radius, slider arrow size, items-3+-collapse-when-static) under our renamed `bc-minicart-suggested-grid` / `bc-wishlist-suggested-grid` wrappers. Necessary because the cart-fragments-safe class rename strips Blocksy's own CSS targeting `.ct-suggested-products--mini-cart`.
 
-### Why this matters
-The class rename in the shared helper escapes WooCommerce's cart-fragments AJAX wipe (`[class*="ct-suggested-products--mini-cart"]`), but Blocksy's customizer-derived inline stylesheet only targets the original class. Without the LAYER 8 CSS shim, items render at `flex: 0 0 100%` (1-column) and use default theme typography. The shim is the missing link that gives all 7 drawer states visual parity with the Blocksy-native "mini cart with items" state (Image #1).
+### Why this matters The class rename in the shared helper escapes WooCommerce's cart-fragments AJAX wipe (`[class*="ct-suggested-products--mini-cart"]`), but Blocksy's customizer-derived inline stylesheet only targets the original class. Without the LAYER 8 CSS shim, items render at `flex: 0 0 100%` (1-column) and use default theme typography. The shim is the missing link that gives all 7 drawer states visual parity with the Blocksy-native "mini cart with items" state (Image #1).
 
-### Architecture
-Memory file: `~/.claude/projects/-Users-jarutosurano-GitHub--claude/memory/blocksy-drawer-suggested-products-architecture.md` documents the 7-state matrix and the rule "DO NOT strip flexy hooks". This entry adds LAYER 8 (column/typography shim) to the bulletproofing strategy already documented (LAYERS 1-7).
+### Architecture Memory file: `~/.claude/projects/-Users-jarutosurano-GitHub--claude/memory/blocksy-drawer-suggested-products-architecture.md` documents the 7-state matrix and the rule "DO NOT strip flexy hooks". This entry adds LAYER 8 (column/typography shim) to the bulletproofing strategy already documented (LAYERS 1-7).
 
 
 ## [86exbz9aq] - 2026-04-28

--- a/assets/js/wishlist-offcanvas.js
+++ b/assets/js/wishlist-offcanvas.js
@@ -29,6 +29,21 @@
 	var REMOVE_ICON = '<svg class="ct-icon" width="10" height="10" viewBox="0 0 24 24" aria-hidden="true"><path d="M9.6,0l0,1.2H1.2v2.4h21.6V1.2h-8.4l0-1.2H9.6z M2.8,6l1.8,15.9C4.8,23.1,5.9,24,7.1,24h9.9c1.2,0,2.2-0.9,2.4-2.1L21.2,6H2.8z"></path></svg>';
 	var GUEST_TEXT = "Guest favorites are only saved to your device for 7 days, or until you clear your cache. Sign in or create an account to hang on to your picks.";
 
+	// Figma "card grid" layout (opt-in per site via bcWishlistData.cardLayout).
+	// When on, items render as a 2-col card grid with a "Remove" text control
+	// (CSS uppercases it). When off (Byron Bay) the original list-row icon
+	// template is used, unchanged. The remove BUTTON + its data-product-id +
+	// aria-label are identical either way, so the remove click handler and
+	// server sync work the same in both layouts.
+	//
+	// Read at RENDER time, not init: the preloaded `bcWishlistData` <script>
+	// prints AFTER this enqueued footer script, so `data.cardLayout` is not
+	// yet defined when this file first executes. Re-reading window.bcWishlistData
+	// inside renderPanel() picks up the real flag once it lands.
+	function usesCards() {
+		return !!( window.bcWishlistData && window.bcWishlistData.cardLayout );
+	}
+
 	// Populate cache from preloaded data.
 	data.items.forEach(function (item) {
 		productCache[item.id] = item;
@@ -233,6 +248,11 @@
 			var isGuest = !document.body.classList.contains("logged-in");
 			var html = "";
 
+			// Toggle the panel's empty/filled state class so the server-rendered
+			// "You May Also Like" block (category grid vs product carousel) shows
+			// the right variant. No-op when card layout is off (classes unused).
+			setPanelEmptyState(items.length === 0);
+
 			if (items.length === 0) {
 				// Empty state — centered message.
 				html = '<div class="ct-wishlist-empty">'
@@ -247,7 +267,9 @@
 				}
 			} else {
 				// Wishlist items.
-				html = '<ul class="woocommerce-mini-cart ct-wishlist-items">';
+				var useCards = usesCards();
+				var removeInner = useCards ? '<span class="ct-wishlist-remove-label">Remove</span>' : REMOVE_ICON;
+				html = '<ul class="woocommerce-mini-cart ct-wishlist-items' + (useCards ? ' ct-wishlist-items--cards' : '') + '">';
 
 				items.forEach(function (id) {
 					var product = productCache[id];
@@ -260,7 +282,7 @@
 						+ '<span class="price">' + product.price + '</span>'
 						+ '</div>'
 						+ '<button class="ct-wishlist-remove" data-product-id="' + product.id + '" aria-label="Remove from wishlist">'
-						+ REMOVE_ICON
+						+ removeInner
 						+ '</button>'
 						+ '</li>';
 				});
@@ -291,6 +313,19 @@
 	function updateHeadingCount(count) {
 		var countEl = document.querySelector(PANEL_SEL + " .ct-wishlist-count-number");
 		if (countEl) countEl.textContent = count;
+	}
+
+	/**
+	 * Toggle the panel's empty/filled state class. Card layout uses it (CSS)
+	 * to swap the empty-state category grid for the filled-state suggested
+	 * products carousel. Harmless when card layout is off — the classes are
+	 * simply unstyled.
+	 */
+	function setPanelEmptyState(isEmpty) {
+		var panel = document.querySelector(PANEL_SEL);
+		if (!panel) return;
+		panel.classList.toggle("ct-wishlist-state-empty", isEmpty);
+		panel.classList.toggle("ct-wishlist-state-filled", !isEmpty);
 	}
 
 	// ==========================================================================
@@ -541,6 +576,9 @@
 		if (document.querySelectorAll(PANEL_SEL + " .ct-wishlist-item").length === 0) {
 			var inner = document.querySelector(CONTENT_SEL);
 			if (!inner) return;
+
+			// Last item removed — swap to the empty-state "You May Also Like".
+			setPanelEmptyState(true);
 
 			var isGuest = !document.body.classList.contains("logged-in");
 			var html = '<div class="ct-wishlist-empty">'

--- a/docs/86ey0r46n-wishlist-offcanvas.md
+++ b/docs/86ey0r46n-wishlist-offcanvas.md
@@ -1,0 +1,69 @@
+# 86ey0r46n — Wishlist off-canvas (slide-in) panel → match Figma
+
+**ClickUp:** https://app.clickup.com/t/86ey0r46n (in-progress · Lan · Alternate Worlds) **Staging:** https://aworld-retheme.blz.au · **Started:** 2026-06-30 · **Status:** In Progress **Plan:** ~/.claude-dev-blazecommerce-io/plans/https-app-clickup-com-t-36771024-86ey0r4-jaunty-beacon.md **Final step (user):** run `/figma-staging-audit` against the staging drawer once fidelity is done.
+
+## Objective Refine the existing wishlist off-canvas drawer (`#woo-wishlist-panel`) to match Figma across desktop/tablet/mobile, then audit. Not from-scratch — the drawer exists and **already opens** on staging.
+
+## Environment & architecture (verified 2026-06-30)
+- Active theme **`blocksy-child`** (parent `blocksy`), WP 7.0 / Woo 10.8.1. Theme dir `…/themes/blocksy-child/`. Deployed **v1.1.46** (origin/main = **1.1.48** — staging slightly behind; drawer files are current though).
+- **Drawer core = `blaze-blocksy`** repo (`github.com/blaze-commerce/blaze-blocksy`): `inc/wishlist-offcanvas.php`, `assets/js/wishlist-offcanvas.js`, `assets/css/components/wishlist-offcanvas.css` (+ shared `offcanvas.css`). Deploy = **SSH-rsync/scp** to the theme dir + `touch inc/enqueue.php`.
+- **AW overlay = `bc-site-customizations` → `sites/alternateworlds/custom/`** — deploys INTO `blocksy-child/custom/` (loaded via `functions.php` → `custom/custom.php`). Confirmed live: `custom/css/design-tokens.css|product-card.css|slider.css` (ver 1782790908) are enqueued. Deploy = PR + **`ready-for-qa-v1`** label (CI). Also `clients/alternateworlds/alternateworlds.css` loads (blaze-blocksy client system).
+- **Decision:** AW-specific Figma fidelity (CSS + AW copy/category-grid) → **AW overlay** (`sites/alternateworlds/custom/css/wishlist-offcanvas.css`), no Byron Bay regression. Touch `blaze-blocksy` core only for unavoidable structural/JS changes.
+
+## Worktrees
+- blaze-blocksy core: `/Users/alanregaya/Documents/.work/.blz/.worktrees/blaze-blocksy-wishlist-1782792038` (branch `feat/wishlist-offcanvas-figma-86ey0r46n`, off origin/main `0da9e7f`).
+- AW overlay (bc-site-customizations): TBD — `bc-sc-wt-86ey0r46n` (to create).
+
+## Current drawer behavior (live, verified)
+- Header `.ct-header-wishlist` `<a href=".../my-account/woo-wish-list/">` with `aria-controls=woo-wishlist-panel`. Click → **drawer OPENS** (capture-phase listener in wishlist-offcanvas.js; `panelActive:true`, no navigation). Task's "routes to full page" note is **outdated**. ESC + click-outside close work.
+- Empty state renders: `.ct-wishlist-empty` "Your Wishlist is Empty" + `.ct-wishlist-guest-notice` (7-day copy, matches Figma) + `.ct-wishlist-signup-btn` "Sign Up". Suggested = Blocksy carousel "SUGGESTED PRODUCTS".
+- Item template (JS): `.ct-wishlist-item` = image link + `.ct-wishlist-item-info` (title link + `.price` = `get_price_html()` incl. sale del/ins) + `.ct-wishlist-remove` icon button.
+- Panel width `--side-panel-width` mirrored from cart Customizer (`header_placements` → cart `cart_panel_width`); default desktop 500 / tablet 65vw / mobile 90vw (Figma: desktop **451**, mobile **346**).
+
+## Figma deltas (empty state, desktop — screenshots in scratchpad)
+1. Title "Wishlist" → **"WISHLIST"** uppercase bold (`.ct-wishlist-panel-title` + count). [CSS]
+2. Close X → **X in bordered square** (`.ct-toggle-close` border). [CSS]
+3. "Your Wishlist is Empty" left → **centered**, Figma weight/size. [CSS]
+4. Guest notice **filled blue box → no box**, plain centered copy. [CSS]
+5. CTA blue "SIGN UP" → **outlined "REGISTER"** (white bg, dark/orange border, dark text). [label + CSS]
+6. Suggested "SUGGESTED PRODUCTS" carousel → **"You May Also Like" 2×2 category grid** (COMICS/COLLECTABLES/GAMES/TOYS + counts) for EMPTY; product cards for FILLED. [heading + grid — check `woo-category-grid.css` / homepage `category-cards` block for reuse]
+
+## Figma tokens (re-extract exact per BP at build) Primary **Barlow Semi Condensed**, secondary **Inter**; title H6 20/24/700; body/links 14; text `#343437`, sale `#cb2f00`, blue `#02478f`, border `#d1d9e6`, secondary `#575757`; radius-xs 2; product-card min-w 140. Blocksy mobile BP **690px**.
+
+## Figma nodes Desktop filled `30639-224597` / empty `21316-76971`; Tablet `23310-35577` / `23310-35575`; Mobile `2138-116628` / `2138-116569`.
+
+## Decision (final): ALL changes in the AW overlay (bc-site-customizations), single PR + `ready-for-qa-v1` deploy Reverted the core blaze-blocksy JS edit. The "REGISTER" label is done via a tiny AW overlay JS relabel (MutationObserver on the drawer), so the shared core (and Byron Bay) is untouched. Deploy = `bash deploy.sh --site alternateworlds --env v1` from the overlay worktree (needs `ssh-add ~/.ssh/impactfurniture_ed25519` first — deploy.sh connects by IP, not the alias). Host is GCP (not *.kinsta.cloud) so no Kinsta edge cache; cf DYNAMIC / kinsta BYPASS.
+
+## Change Log
+| # | Timestamp | File | Action | Description |
+|---|-----------|------|--------|-------------|
+| 1 | 2026-06-30 | sites/alternateworlds/custom/css/wishlist-offcanvas.css | Created | Header uppercase/700, bordered-X close, centered empty msg, de-boxed guest notice, outlined REGISTER, filled-item title/sale-price colours. All scoped `#woo-wishlist-panel`. |
+| 2 | 2026-06-30 | sites/alternateworlds/custom/js/wishlist-offcanvas.js | Created | Relabel guest CTA "Sign Up"→"REGISTER" (overlay, not core). |
+| 3 | 2026-06-30 | sites/alternateworlds/custom/custom.php | Modified | Enqueue the new wishlist css + js (global). |
+| 4 | 2026-06-30 | (deploy) | — | `deploy.sh --site alternateworlds --env v1` → staging. Verified both overlay assets load after core; CTA="REGISTER"; title uppercases. |
+
+## First-pass result (verified on staging, desktop) DONE vs Figma: WISHLIST uppercase ✓, bordered-X close ✓, de-boxed guest notice ✓, outlined REGISTER ✓. REMAINING (for /figma-staging-audit): empty-message **centering not applied** (still left); panel **width 451px** (currently ~500 from cart Customizer); filled-item spacing/badge; **"You May Also Like" heading + category grid** (delta 6 — reuse `woo-category-grid.css` via `[product_categories]`); full **7-BP responsive** (320–2560 + 690).
+
+## Round 2 — structural parity (user chose "build full structural parity now") The audit surfaced two structural deltas beyond CSS fidelity: filled items as a **2-col card grid** and the empty state as a **category grid**. These need shared-core markup/JS (image size, item template, category render), so they went into `blaze-blocksy` core behind a **per-site filter** (`blocksy_child_wishlist_card_layout`, default OFF) — Byron Bay renders byte-for-byte as before. AW opts in + styles in the overlay.
+
+### Core (`blaze-blocksy`, branch `feat/wishlist-offcanvas-figma-86ey0r46n`, commit `1f41cfe`, theme 1.1.48→1.1.49)
+- `inc/wishlist-offcanvas.php`: `blocksy_child_wishlist_uses_cards()` gate; `blocksy_child_wishlist_image_size()` → `woocommerce_single` (portrait) when on; `cardLayout` in `bcWishlistData`; `blocksy_child_render_wishlist_categories()` (empty-state grid: top-level cats with a featured term image, live names+counts, `blocksy_child_wishlist_category_ids` filterable); panel gets `ct-wishlist-cards` + server-computed `ct-wishlist-state-empty|filled`.
+- `assets/js/wishlist-offcanvas.js`: card item template (`ct-wishlist-items--cards`, "Remove" text control); `setPanelEmptyState()` toggles category-grid vs suggested-carousel; card flag read at RENDER time via `usesCards()` (preload `<script>` prints after this footer script — init-time read returned false; the real bug fix).
+- Deploy = scp 2 files to `blocksy-child/{inc,assets/js}/` (filemtime-versioned).
+
+### Overlay (`bc-site-customizations` → `sites/alternateworlds/custom/`, commits `5a30d23`+`9c0af11`, merged `origin/main`)
+- `custom.php`: `add_filter('blocksy_child_wishlist_card_layout','__return_true')`.
+- `css/wishlist-offcanvas.css` §10–§13: card grid, REMOVE link, category grid, empty/filled state toggle (+ empty-state content sizes to content so the REGISTER button isn't clipped by the category grid's flex height).
+
+### Verified on staging (desktop 1440 + mobile 375, both states)
+- Filled: 2-col grid, portrait `woocommerce_single` covers (204×300 from srcset), 2-line title clamp, sale prices, "REMOVE" underlined link; no horizontal overflow (panel 451/345px).
+- Empty: centered "Your Wishlist is Empty" + 7-day notice + outlined REGISTER + "You May Also Like" 2-col category grid (COMICS 158,172 / GAMES 7,851 / TOYS·NOVELTIES 1,326 — 3 of Figma's 4; auto-completes to 2×2 when the client adds a top-level Collectables cat + thumbnail).
+- Byron Bay safety: every core change behind the filter (static-reviewed diff); flag-off path is the original list-row drawer.
+
+### Deferred / notes
+- "Ordered N days ago" image badge — Figma scaffold, no wishlist data source; omitted pending a product decision.
+- **Shared-staging contention:** v1 (`aworld-retheme.blz.au`) is shared; another active PR (task `86exr72z6`, minicart) deploys its branch there too and clobbered the wishlist files mid-session (its tree lacks them, deploy used `--delete`). Reconciled to my branch state (`origin/main` had already removed minicart in `86exr72yj`). Final QA needs a coordinated single-PR label-deploy; the real fix is both PRs merging to `main`.
+
+## Next steps
+1. PRs: `blaze-blocksy` (core) + `bc-site-customizations` (overlay) → `ready-for-qa-v1`.
+2. ClickUp Doc + comment + before/after composites.

--- a/inc/wishlist-offcanvas.php
+++ b/inc/wishlist-offcanvas.php
@@ -21,6 +21,36 @@ if ( ! function_exists( 'blc_get_ext' ) || ! blc_get_ext( 'woocommerce-extra' ) 
 }
 
 /**
+ * Whether the wishlist drawer uses the Figma "card grid" layout.
+ *
+ * OFF by default — every existing site (Byron Bay) keeps the original
+ * list-row drawer byte-for-byte. A site opts in with:
+ *   add_filter( 'blocksy_child_wishlist_card_layout', '__return_true' );
+ * Alternate Worlds enables it in its custom/ overlay. This single gate
+ * governs the card item template, the portrait product image size, and
+ * the empty-state category grid below.
+ *
+ * @return bool
+ */
+function blocksy_child_wishlist_uses_cards() {
+	return (bool) apply_filters( 'blocksy_child_wishlist_card_layout', false );
+}
+
+/**
+ * Image size used for wishlist drawer thumbnails.
+ *
+ * Card layout shows a full portrait product cover (`woocommerce_single`, the
+ * uncropped product image — `woocommerce_thumbnail` is a hard square crop that
+ * lops the top/bottom off portrait comic covers); the list-row layout keeps
+ * the small square `woocommerce_gallery_thumbnail` it always used.
+ *
+ * @return string
+ */
+function blocksy_child_wishlist_image_size() {
+	return blocksy_child_wishlist_uses_cards() ? 'woocommerce_single' : 'woocommerce_gallery_thumbnail';
+}
+
+/**
  * Render the wishlist off-canvas panel shell into the footer.
  * Content is empty — JS fills it from preloaded data.
  */
@@ -55,7 +85,7 @@ add_action( 'wp_footer', function () {
 				'id'    => $product_id,
 				'name'  => $product->get_name(),
 				'url'   => $product->get_permalink(),
-				'image' => $product->get_image( 'woocommerce_gallery_thumbnail' ),
+				'image' => $product->get_image( blocksy_child_wishlist_image_size() ),
 				'price' => $product->get_price_html(),
 			];
 		}
@@ -66,6 +96,7 @@ add_action( 'wp_footer', function () {
 		'isGuest'    => ! is_user_logged_in(),
 		'accountUrl' => wc_get_page_permalink( 'myaccount' ),
 		'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
+		'cardLayout' => blocksy_child_wishlist_uses_cards(),
 	];
 
 	echo '<script id="bc-wishlist-data">var bcWishlistData = ' . wp_json_encode( $preload ) . ';</script>';
@@ -187,6 +218,80 @@ function blocksy_child_render_wishlist_suggested() {
 }
 
 /**
+ * Render the empty-state "You May Also Like" category grid.
+ *
+ * Figma's wishlist empty state replaces the suggested-products carousel with
+ * a 2-column grid of top-level product categories (cover image + name + live
+ * product count). Card layout only — returns '' otherwise, so Byron Bay never
+ * sees this markup.
+ *
+ * Selection is data-driven: top-level product categories that have a curated
+ * term thumbnail (the site's "featured" categories). A site can override the
+ * exact set with the `blocksy_child_wishlist_category_ids` filter (array of
+ * term IDs). Names + counts are always live WooCommerce data — never the
+ * Figma scaffold values.
+ *
+ * @return string
+ */
+function blocksy_child_render_wishlist_categories() {
+	if ( ! blocksy_child_wishlist_uses_cards() || ! function_exists( 'get_terms' ) ) {
+		return '';
+	}
+
+	// Allow a site to curate the exact category set; otherwise auto-pick
+	// top-level categories that have a featured term image.
+	$curated_ids = apply_filters( 'blocksy_child_wishlist_category_ids', [] );
+
+	$terms = [];
+	if ( ! empty( $curated_ids ) && is_array( $curated_ids ) ) {
+		$terms = get_terms( [
+			'taxonomy'   => 'product_cat',
+			'include'    => array_map( 'absint', $curated_ids ),
+			'orderby'    => 'include',
+			'hide_empty' => false,
+		] );
+	} else {
+		$top = get_terms( [
+			'taxonomy'   => 'product_cat',
+			'parent'     => 0,
+			'hide_empty' => true,
+			'orderby'    => 'count',
+			'order'      => 'DESC',
+		] );
+
+		if ( ! is_wp_error( $top ) ) {
+			foreach ( $top as $term ) {
+				if ( (int) get_term_meta( $term->term_id, 'thumbnail_id', true ) > 0 ) {
+					$terms[] = $term;
+				}
+			}
+		}
+	}
+
+	if ( is_wp_error( $terms ) || empty( $terms ) ) {
+		return '';
+	}
+
+	$terms = array_slice( $terms, 0, 4 );
+	$cards = '';
+
+	foreach ( $terms as $term ) {
+		$thumb_id  = (int) get_term_meta( $term->term_id, 'thumbnail_id', true );
+		$image     = $thumb_id ? wp_get_attachment_image( $thumb_id, 'woocommerce_thumbnail', false, [ 'alt' => $term->name, 'loading' => 'lazy' ] ) : '';
+		$count_txt = sprintf( _n( '%s product', '%s products', $term->count, 'blocksy-child' ), number_format_i18n( $term->count ) );
+
+		$cards .= '<a class="ct-wishlist-category-card" href="' . esc_url( get_term_link( $term ) ) . '">'
+			. '<span class="ct-wishlist-category-media">' . $image . '</span>'
+			. '<span class="ct-wishlist-category-name">' . esc_html( $term->name ) . '</span>'
+			. '<span class="ct-wishlist-category-count">' . esc_html( $count_txt ) . '</span>'
+			. '</a>';
+	}
+
+	return '<div class="ct-module-title">You May Also Like</div>'
+		. '<div class="ct-wishlist-category-grid">' . $cards . '</div>';
+}
+
+/**
  * AJAX endpoint — fetch product details for wishlist drawer.
  *
  * Security: requires `bc_wishlist` nonce (added 2026-05-08 — was missing,
@@ -217,7 +322,7 @@ function blocksy_child_ajax_wishlist_product() {
 		'id'    => $product_id,
 		'name'  => $product->get_name(),
 		'url'   => $product->get_permalink(),
-		'image' => $product->get_image( 'woocommerce_gallery_thumbnail' ),
+		'image' => $product->get_image( blocksy_child_wishlist_image_size() ),
 		'price' => $product->get_price_html(),
 	] );
 }
@@ -261,7 +366,26 @@ function blocksy_child_render_wishlist_panel() {
 	// Render suggested products (server-side, same as mini cart).
 	$suggested_html = blocksy_child_render_wishlist_suggested();
 
-	return '<div id="woo-wishlist-panel" class="ct-panel" data-behaviour="right-side" role="dialog" aria-label="Wishlist panel" inert>
+	// Card layout adds: a per-panel class (CSS scope), an empty-state category
+	// grid, and an initial empty/filled state class so the right "You May Also
+	// Like" block shows without a flash. JS keeps the state class in sync as
+	// items are added/removed. All no-ops when card layout is off.
+	$uses_cards     = blocksy_child_wishlist_uses_cards();
+	$categories_html = blocksy_child_render_wishlist_categories();
+
+	$panel_classes = 'ct-panel';
+	if ( $uses_cards ) {
+		$panel_classes .= ' ct-wishlist-cards';
+
+		$server_count   = count( blocksy_child_wishlist_current_ids() );
+		$panel_classes .= $server_count > 0 ? ' ct-wishlist-state-filled' : ' ct-wishlist-state-empty';
+	}
+
+	$categories_block = $uses_cards
+		? '<div class="ct-wishlist-categories">' . $categories_html . '</div>'
+		: '';
+
+	return '<div id="woo-wishlist-panel" class="' . esc_attr( $panel_classes ) . '" data-behaviour="right-side" role="dialog" aria-label="Wishlist panel" inert>
 		<div class="ct-panel-inner">
 			<div class="ct-panel-actions">
 				<h2 class="ct-panel-heading">' . $heart_icon . ' <span class="ct-wishlist-panel-title">Wishlist</span> <span class="ct-wishlist-panel-count">(<span class="ct-wishlist-count-number">0</span>)</span></h2>
@@ -270,7 +394,40 @@ function blocksy_child_render_wishlist_panel() {
 			<div class="ct-panel-content">
 				<div class="ct-panel-content-inner"></div>
 			</div>
+			' . $categories_block . '
 			<div class="ct-wishlist-suggested">' . $suggested_html . '</div>
 		</div>
 	</div>';
+}
+
+/**
+ * Current wishlist product IDs (server-side), or [] when unavailable.
+ *
+ * Shared by the suggested carousel and the initial card-layout state class.
+ *
+ * @return int[]
+ */
+function blocksy_child_wishlist_current_ids() {
+	if ( ! function_exists( 'blc_get_ext' ) ) {
+		return [];
+	}
+
+	$ext = blc_get_ext( 'woocommerce-extra' );
+	if ( ! $ext || ! method_exists( $ext, 'get_wish_list' ) ) {
+		return [];
+	}
+
+	$wish_list_ext = $ext->get_wish_list();
+	if ( ! $wish_list_ext || ! method_exists( $wish_list_ext, 'get_current_wish_list' ) ) {
+		return [];
+	}
+
+	$items = $wish_list_ext->get_current_wish_list();
+	if ( ! is_array( $items ) ) {
+		return [];
+	}
+
+	return array_values( array_filter( array_map( function ( $item ) {
+		return isset( $item['id'] ) ? (int) $item['id'] : 0;
+	}, $items ) ) );
 }

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:       Blaze Commerce
  Author URI:   https://blazecommerce.io/
  Template:     blocksy
- Version:      1.1.48
+ Version:      1.1.49
  Text Domain:  blocksy-child
  License:      GNU General Public License v2 or later
  License URI:  https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary

Adds an opt-in **`blocksy_child_wishlist_card_layout`** filter (default `false`) that switches the off-canvas wishlist drawer to the Figma "card grid" layout, for [86ey0r46n — Wishlist off-canvas panel](https://app.clickup.com/t/86ey0r46n) (Alternate Worlds). When the filter is on:

- **Filled items** render as a 2-col card grid (image over info) with a **"Remove"** text control instead of the list-row + trash icon.
- The thumbnail uses **`woocommerce_single`** (full portrait cover) instead of the square `woocommerce_gallery_thumbnail` that hard-crops portrait comic covers.
- The **empty state** shows a "You May Also Like" 2-col **category grid** (top-level product categories that have a featured term image — live names + counts; `blocksy_child_wishlist_category_ids`-filterable) in place of the suggested-products carousel, toggled by an empty/filled state class kept in sync by JS (seeded server-side to avoid a flash).

Alternate Worlds opts in + styles it in its `bc-site-customizations` overlay (companion PR). The card flag is read at **render time** in JS because the preload `<script>` prints after this footer script.

### Byron Bay / other-site safety Every change is gated behind the filter. With it **off** (Byron Bay and every other site) the drawer renders byte-for-byte as before — the only additions are an inert `cardLayout:false` data field and unstyled `ct-wishlist-state-*` classes. Static-reviewed: no ungated change to the shared render path. Theme `1.1.48 → 1.1.49`.

## Test plan

- [x] PHP lint clean (`php -l`) on `inc/wishlist-offcanvas.php`; `node --check` on the JS.
- [x] AW staging (filter on), **filled**, desktop 1440 + mobile 375: 2-col card grid, portrait `woocommerce_single` covers (204×300 from srcset), 2-line title clamp, sale prices, "REMOVE" underlined link; no horizontal overflow (panel 451 / 345px).
- [x] AW staging (filter on), **empty**: centered "Your Wishlist is Empty" + 7-day notice + outlined REGISTER + "You May Also Like" category grid (live counts 158,172 / 7,851 / 1,326).
- [x] Gating reviewed: flag-off path = original list-row drawer (image `woocommerce_gallery_thumbnail`, trash icon, no category grid, panel class `ct-panel`).
- [ ] Reviewer: confirm Byron Bay drawer unchanged after deploy (filter unset).

## Notes

- "Ordered N days ago" image badge from Figma is omitted — scaffold with no wishlist data source; pending a product decision.
- Deploy is scp of the two theme files (`inc/` + `assets/js/`), filemtime-versioned.

---

**RESUME SESSION**

```bash
cd /Users/alanregaya/Documents/.work/.blz/.worktrees/blaze-blocksy-wishlist-1782792038 && claude --resume 39f0db3c-0ef5-4a2b-9e28-4c2421e282f1 --permission-mode plan
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
