### PR TITLE
fix(wishlist): empty-state category grid → curated 4 + tilted collage media (86ey0r46n)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [wishlist-drawer-category-grid-fix-2026-06-30] - 2026-06-30
+
+### Fixed
+- `inc/wishlist-offcanvas.php` — `blocksy_child_render_wishlist_categories()`: the empty-state "You May Also Like" grid auto-picked only top-level terms that had a `thumbnail_id`, which silently dropped categories without one (Alternate Worlds rendered 3 cards / 2+1 instead of the Figma 2×2). It now **defaults to the site's curated Shop-by-Category set** (`aw_category_cards_default_categories()` term IDs) when no `blocksy_child_wishlist_category_ids` override is set, and **resolves media via `aw_category_cards_image_htmls( 0, $term, 2 )`** — one curated cover or two auto-resolved portrait covers, wrapped in `.ct-wishlist-category-img-wrap` (+ `--single`) — so a thumbnail-less term still shows art and the cards match the homepage/minicart collage. Both behind `function_exists()` guards; falls back to the bare term thumbnail for sites without the AW helpers. ClickUp 86ey0r46n.
+
 ## [wishlist-card-grid-layout-2026-06-30] - 2026-06-30
 
 ### Added

--- a/inc/wishlist-offcanvas.php
+++ b/inc/wishlist-offcanvas.php
@@ -242,6 +242,18 @@ function blocksy_child_render_wishlist_categories() {
 	// top-level categories that have a featured term image.
 	$curated_ids = apply_filters( 'blocksy_child_wishlist_category_ids', [] );
 
+	// Default to the site's curated "Shop by Category" set (the four Figma cards:
+	// Comics, Collectables, Games, Toys/Novelties) so the drawer matches the
+	// homepage/minicart instead of auto-picking only thumbnail-bearing terms
+	// (which silently dropped Collectables → a 2+1 grid instead of the 2×2).
+	if ( empty( $curated_ids ) && function_exists( 'aw_category_cards_default_categories' ) ) {
+		$curated_ids = array_slice(
+			wp_list_pluck( aw_category_cards_default_categories(), 'termId' ),
+			0,
+			4
+		);
+	}
+
 	$terms = [];
 	if ( ! empty( $curated_ids ) && is_array( $curated_ids ) ) {
 		$terms = get_terms( [
@@ -276,12 +288,28 @@ function blocksy_child_render_wishlist_categories() {
 	$cards = '';
 
 	foreach ( $terms as $term ) {
-		$thumb_id  = (int) get_term_meta( $term->term_id, 'thumbnail_id', true );
-		$image     = $thumb_id ? wp_get_attachment_image( $thumb_id, 'woocommerce_thumbnail', false, [ 'alt' => $term->name, 'loading' => 'lazy' ] ) : '';
 		$count_txt = sprintf( _n( '%s product', '%s products', $term->count, 'blocksy-child' ), number_format_i18n( $term->count ) );
 
+		// Match the homepage/minicart "Shop by Category" media: one curated cover
+		// when the term has a thumbnail, otherwise up to two auto-resolved portrait
+		// product covers — so a thumbnail-less term (e.g. Collectables) still shows
+		// art instead of an empty box. Falls back to the bare term thumbnail when
+		// the AW helper is absent (another site using this parent theme).
+		if ( function_exists( 'aw_category_cards_image_htmls' ) ) {
+			$covers    = aw_category_cards_image_htmls( 0, $term, 2 );
+			$media_mod = ( count( $covers ) < 2 ) ? ' ct-wishlist-category-media--single' : '';
+			$image     = '';
+			foreach ( $covers as $cover ) {
+				$image .= '<span class="ct-wishlist-category-img-wrap">' . $cover . '</span>';
+			}
+		} else {
+			$thumb_id  = (int) get_term_meta( $term->term_id, 'thumbnail_id', true );
+			$media_mod = '';
+			$image     = $thumb_id ? wp_get_attachment_image( $thumb_id, 'woocommerce_thumbnail', false, [ 'alt' => $term->name, 'loading' => 'lazy' ] ) : '';
+		}
+
 		$cards .= '<a class="ct-wishlist-category-card" href="' . esc_url( get_term_link( $term ) ) . '">'
-			. '<span class="ct-wishlist-category-media">' . $image . '</span>'
+			. '<span class="ct-wishlist-category-media' . esc_attr( $media_mod ) . '">' . $image . '</span>'
 			. '<span class="ct-wishlist-category-name">' . esc_html( $term->name ) . '</span>'
 			. '<span class="ct-wishlist-category-count">' . esc_html( $count_txt ) . '</span>'
 			. '</a>';


### PR DESCRIPTION
## Summary

Parent-theme half of the Alternate Worlds wishlist off-canvas Figma audit (ClickUp 86ey0r46n). Companion overlay PR: blaze-commerce/bc-site-customizations#193.

The wishlist drawer's empty state renders a "Shop by Category" grid via `blocksy_child_render_wishlist_categories()`. Two defects against Figma:

- **Only 3 cards rendered (2+1), Figma shows 4 in a 2×2.** The renderer auto-picked terms that have a `thumbnail_id`; **Collectables** (term 315) has no featured image, so it was silently dropped. Fix: when the `blocksy_child_wishlist_categories` filter yields nothing, default to the **curated 4** termIds from `aw_category_cards_default_categories()` (Comics 6942, Collectables 315, Games 6951, Toys/Novelties 7785) — the same four the homepage "Shop by Category" band uses — sliced to 4, guarded by `function_exists`.
- **Single full-bleed cover, Figma + minicart show a tilted 2-cover collage.** Media now renders via `aw_category_cards_image_htmls( 0, $term, 2 )`, wrapping each cover in `.ct-wishlist-category-img-wrap` and adding a `--single` modifier when only one image resolves. Falls back to the bare thumbnail if the helper is absent (parent theme used standalone).

## Files
- `inc/wishlist-offcanvas.php` — `blocksy_child_render_wishlist_categories()`: curated-4 default + collage markup helper + single-image fallback.

## Test plan
- **Post-merge + deploy** on `aworld-retheme.blz.au` (overlay PR #193 supplies the matching `.ct-wishlist-category-img-wrap` CSS): open the wishlist drawer empty state → 4 category cards in a 2×2 (Comics / Collectables / Games / Toys & Novelties), each with the tilted 68×89 collage covers. Collectables now appears despite having no featured image.
- Parent-theme PHP only persists on shared staging once merged — so this lands via merge → Deploy-main-to-staging, verified by forced cache-MISS fetch.

## ClickUp https://app.clickup.com/t/86ey0r46n

## Resume

```bash
cd /Users/alanregaya/Documents/.work/.blz/.worktrees/blaze-blocksy-wishlist-1782792038 && claude --resume be80adf6-9312-4742-9327-7f841d04b4de
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
