### PR TITLE
fix(wishlist): empty-state category card label → Collectables not raw term name (86ey0r46n)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [wishlist-drawer-category-labels-2026-06-30] - 2026-06-30
+
+### Fixed
+- `inc/wishlist-offcanvas.php` — `blocksy_child_render_wishlist_categories()`: the curated default set previously plucked **only** term IDs and rendered `$term->name`, so the second card showed the raw taxonomy name **"Collectible Games"** instead of the curated label **"Collectables"** (Figma + the homepage "Shop by Category" band). The renderer now carries each curated entry's `label` (and `imageId`) into per-term override maps and renders the label, falling back to `$term->name`. Added the `blocksy_child_wishlist_category_labels` filter (term ID => label) so any site can override labels regardless of curation source. Live counts unchanged. Staging-verified (aworld-retheme.blz.au). ClickUp 86ey0r46n.
+
 ## [wishlist-drawer-category-grid-fix-2026-06-30] - 2026-06-30
 
 ### Fixed

--- a/inc/wishlist-offcanvas.php
+++ b/inc/wishlist-offcanvas.php
@@ -242,17 +242,37 @@ function blocksy_child_render_wishlist_categories() {
 	// top-level categories that have a featured term image.
 	$curated_ids = apply_filters( 'blocksy_child_wishlist_category_ids', [] );
 
+	// Per-term display-label + cover-image overrides, keyed by term ID. The
+	// curated set assigns a friendly label (and may pin a cover) that the raw
+	// term name lacks — e.g. term 315's curated label is "Collectables" but its
+	// raw $term->name is "Collectible Games". Carry both so the drawer card
+	// matches the homepage band + Figma instead of the raw taxonomy name.
+	$label_overrides = [];
+	$image_overrides = [];
+
 	// Default to the site's curated "Shop by Category" set (the four Figma cards:
 	// Comics, Collectables, Games, Toys/Novelties) so the drawer matches the
 	// homepage/minicart instead of auto-picking only thumbnail-bearing terms
 	// (which silently dropped Collectables → a 2+1 grid instead of the 2×2).
 	if ( empty( $curated_ids ) && function_exists( 'aw_category_cards_default_categories' ) ) {
-		$curated_ids = array_slice(
-			wp_list_pluck( aw_category_cards_default_categories(), 'termId' ),
-			0,
-			4
-		);
+		foreach ( array_slice( aw_category_cards_default_categories(), 0, 4 ) as $cat ) {
+			if ( empty( $cat['termId'] ) ) {
+				continue;
+			}
+			$tid           = (int) $cat['termId'];
+			$curated_ids[] = $tid;
+			if ( ! empty( $cat['label'] ) ) {
+				$label_overrides[ $tid ] = $cat['label'];
+			}
+			if ( ! empty( $cat['imageId'] ) ) {
+				$image_overrides[ $tid ] = (int) $cat['imageId'];
+			}
+		}
 	}
+
+	// Any site may supply per-term display-label overrides (term ID => label)
+	// regardless of how the category set was curated.
+	$label_overrides = apply_filters( 'blocksy_child_wishlist_category_labels', $label_overrides );
 
 	$terms = [];
 	if ( ! empty( $curated_ids ) && is_array( $curated_ids ) ) {
@@ -288,15 +308,19 @@ function blocksy_child_render_wishlist_categories() {
 	$cards = '';
 
 	foreach ( $terms as $term ) {
+		// Prefer the curated label ("Collectables") over the raw term name
+		// ("Collectible Games") so the card matches the homepage band + Figma.
+		$label     = isset( $label_overrides[ $term->term_id ] ) ? $label_overrides[ $term->term_id ] : $term->name;
 		$count_txt = sprintf( _n( '%s product', '%s products', $term->count, 'blocksy-child' ), number_format_i18n( $term->count ) );
 
-		// Match the homepage/minicart "Shop by Category" media: one curated cover
-		// when the term has a thumbnail, otherwise up to two auto-resolved portrait
+		// Match the homepage/minicart "Shop by Category" media: a curated cover
+		// (curated imageId, if pinned) otherwise up to two auto-resolved portrait
 		// product covers — so a thumbnail-less term (e.g. Collectables) still shows
 		// art instead of an empty box. Falls back to the bare term thumbnail when
 		// the AW helper is absent (another site using this parent theme).
 		if ( function_exists( 'aw_category_cards_image_htmls' ) ) {
-			$covers    = aw_category_cards_image_htmls( 0, $term, 2 );
+			$img_id    = isset( $image_overrides[ $term->term_id ] ) ? $image_overrides[ $term->term_id ] : 0;
+			$covers    = aw_category_cards_image_htmls( $img_id, $term, 2 );
 			$media_mod = ( count( $covers ) < 2 ) ? ' ct-wishlist-category-media--single' : '';
 			$image     = '';
 			foreach ( $covers as $cover ) {
@@ -305,12 +329,12 @@ function blocksy_child_render_wishlist_categories() {
 		} else {
 			$thumb_id  = (int) get_term_meta( $term->term_id, 'thumbnail_id', true );
 			$media_mod = '';
-			$image     = $thumb_id ? wp_get_attachment_image( $thumb_id, 'woocommerce_thumbnail', false, [ 'alt' => $term->name, 'loading' => 'lazy' ] ) : '';
+			$image     = $thumb_id ? wp_get_attachment_image( $thumb_id, 'woocommerce_thumbnail', false, [ 'alt' => $label, 'loading' => 'lazy' ] ) : '';
 		}
 
 		$cards .= '<a class="ct-wishlist-category-card" href="' . esc_url( get_term_link( $term ) ) . '">'
 			. '<span class="ct-wishlist-category-media' . esc_attr( $media_mod ) . '">' . $image . '</span>'
-			. '<span class="ct-wishlist-category-name">' . esc_html( $term->name ) . '</span>'
+			. '<span class="ct-wishlist-category-name">' . esc_html( $label ) . '</span>'
 			. '<span class="ct-wishlist-category-count">' . esc_html( $count_txt ) . '</span>'
 			. '</a>';
 	}


### PR DESCRIPTION
## Summary

Follow-up to #246, found during the post-deploy staging audit of the Alternate Worlds wishlist off-canvas drawer (ClickUp 86ey0r46n).

The empty-state category grid's curated default plucked **only** term IDs from `aw_category_cards_default_categories()` and then rendered `$term->name`. Term 315's raw taxonomy name is **"Collectible Games"**, but its curated label — used by the homepage "Shop by Category" band and shown in Figma — is **"Collectables"**. So card #2 in the drawer read "Collectible Games" while the homepage + Figma read "Collectables".

Fix: carry each curated entry's `label` (and `imageId`) into per-term override maps and render the label, falling back to `$term->name` when no override exists. Added a `blocksy_child_wishlist_category_labels` filter (term ID => label) so any site can override labels independently of the curation source. Live product counts unchanged.

## Files
- `inc/wishlist-offcanvas.php` — `blocksy_child_render_wishlist_categories()`: build `$label_overrides` / `$image_overrides` from the curated set; render `$label`; new labels filter.

## Test plan
- **Staging-verified (aworld-retheme.blz.au):** before this fix the drawer empty-state showed COMICS / **COLLECTIBLE GAMES** / GAMES / TOYS-NOVELTIES; the homepage band shows COMICS / **COLLECTABLES** / GAMES / TOYS-NOVELTIES. After deploy → drawer card #2 reads **COLLECTABLES**, matching the homepage band + Figma. 4-card 2×2 grid and tilted collage covers (from #246) unchanged; counts unchanged.

## ClickUp https://app.clickup.com/t/86ey0r46n

## Resume

```bash
cd /Users/alanregaya/Documents/.work/.blz/.worktrees/blaze-blocksy-wishlist-1782792038 && claude --resume be80adf6-9312-4742-9327-7f841d04b4de
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
