### PR TITLE
feat(loader): generic overlay hook for non-manifest sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ node_modules/
 project-config.json
 .env
 .env.*
+
+# Per-site overlay deployed by the bc-site-customizations repo's own CI (see inc/loader.php)
+# — owned by that repo, never tracked here.
+custom/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [custom-overlay-hook-2026-07-07] - 2026-07-07
+
+### Added
+- `inc/loader.php` — generic, unconditional `custom/custom.php` require (file_exists-guarded), loaded right after the core modules and before the `clients/` manifest system. Lets a site use the traditional `bc-site-customizations` monorepo `custom/` overlay (deployed by that repo's own CI into this theme's `custom/` directory) instead of, or alongside, the `clients/<slug>/manifest.json` system. First consumer: thenaturalmattress.com (ClickUp 86ey6h6p2) — a new site build that needed this theme's real code but not the Byron Bay-style client manifest.
+- `.gitignore` — excludes `custom/` (owned/deployed by the `bc-site-customizations` repo, never tracked here).
+
+### Changed
+- Theme 1.1.49 -> 1.1.50.
+
 ## [wishlist-drawer-category-labels-2026-06-30] - 2026-06-30
 
 ### Fixed

--- a/inc/loader.php
+++ b/inc/loader.php
@@ -70,6 +70,15 @@ blocksy_child_load_module( 'inc/icons.php' );
 blocksy_child_load_module( 'inc/offcanvas-icons.php' );
 blocksy_child_load_module( 'inc/carousel.php' );
 
+// --- Site-specific overlay (bc-site-customizations monorepo) ---
+// Sites deployed the traditional way (not via clients/<slug>/manifest.json) ship their
+// site-specific PHP/CSS/JS as custom/custom.php, deployed into THIS theme's custom/
+// directory by the bc-site-customizations repo's own CI. Unconditional and independent
+// of the clients/ system below — both can be used on the same site if ever needed.
+if ( file_exists( BLOCKSY_CHILD_PATH . 'custom/custom.php' ) ) {
+	blocksy_child_load_module( 'custom/custom.php' );
+}
+
 // --- Client Modules (load BEFORE WooCommerce modules so feature flags are available) ---
 blocksy_child_load_clients();
 

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:       Blaze Commerce
  Author URI:   https://blazecommerce.io/
  Template:     blocksy
- Version:      1.1.49
+ Version:      1.1.50
  Text Domain:  blocksy-child
  License:      GNU General Public License v2 or later
  License URI:  https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary
- Adds a generic, unconditional, file_exists-guarded require for a site's bc-site-customizations overlay entry file in inc/loader.php -- independent of and compatible alongside the clients/<slug>/manifest.json system.
- First consumer: thenaturalmattress.com (ClickUp 86ey6h6p2) -- needs this theme's real tracked code but doesn't use the Byron Bay-style client manifest.
- .gitignore excludes the overlay directory (owned by the bc-site-customizations repo's own deploy, never tracked here).
- Theme version bumped 1.1.49 -> 1.1.50.
- No CI in this repo (deploy is manual SSH per README) -- this PR is for review/history; actual deploy to tnmretheme.kinsta.cloud staging happens via SSH after merge.

## Test plan
- [x] Confirmed loader.php's new require is guarded by file_exists() -- a site without the overlay file sees zero behavior change
- [ ] Deploy real theme files to tnmretheme.kinsta.cloud staging and verify site renders correctly with the overlay loading

RESUME: cd /Users/alanregaya/Documents/.work/.blz && claude --resume fbc117b2-c475-4998-8a72-5e4fdaff19c6 --permission-mode plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>