### PR TITLE
fix: enqueue archive polish on all product taxonomy archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [enqueue-product-taxonomy-archive-2026-07-13] - 2026-07-13
+
+### Fixed
+- `inc/enqueue.php` — the `woo-archive.css` + `shop-customizations.js` archive-polish gate was `is_shop() || is_product_category() || is_product_tag() || is_front_page()`, which excluded custom product taxonomies. Custom-taxonomy archives (`product_brand`, product-attribute `pa_*`) render the same product cards but loaded neither asset, so the "See More" add-to-cart button sat at ~132px auto-width instead of filling the card and the `.woo-listing-top` result/sort bar lost its borders. Broadened the gate to `is_shop() || is_product_taxonomy() || is_front_page()` — `is_product_taxonomy()` is `is_tax( get_object_taxonomies('product') )`, a superset of category+tag that also covers `product_brand` and `pa_*`. Surfaced on the TNM `product_brand` archive (ClickUp 86ey91293); the TNM overlay (bc-site-customizations #327) enqueues the same assets under the same base handles scoped to `is_tax('product_brand')`, so once this lands WP dedupes and the overlay becomes a no-op. Theme 1.1.49 -> 1.1.50.
+
 ## [wishlist-drawer-category-labels-2026-06-30] - 2026-06-30
 
 ### Fixed

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -57,7 +57,10 @@ function blocksy_child_enqueue_styles() {
 		// woo-archive.css contains product card styles (full-width buttons, price
 		// suffix). Load on any page that renders product cards: archive pages AND
 		// homepage (product slider shortcode). One file, one source of truth.
-		if ( is_shop() || is_product_category() || is_product_tag() || is_front_page() ) {
+		// is_product_taxonomy() == is_tax( get_object_taxonomies('product') ), so it
+		// covers category + tag AND custom product taxonomies (product_brand, pa_*),
+		// which the previous is_product_category/is_product_tag pair excluded.
+		if ( is_shop() || is_product_taxonomy() || is_front_page() ) {
 			blocksy_child_enqueue_component( 'woo-archive', $css_url, $css_path );
 
 			// Shop-customizations JS — result count repositioning + AJAX update + sort label tweak.

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:       Blaze Commerce
  Author URI:   https://blazecommerce.io/
  Template:     blocksy
- Version:      1.1.49
+ Version:      1.1.50
  Text Domain:  blocksy-child
  License:      GNU General Public License v2 or later
  License URI:  https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary
The archive-polish assets (`assets/css/components/woo-archive.css` and `assets/js/shop-customizations.js`) were gated behind `is_shop() || is_product_category() || is_product_tag() || is_front_page()` in `inc/enqueue.php`. That gate excludes custom product taxonomies, so `product_brand` archives and product-attribute (`pa_*`) archives loaded neither asset even though they render the same product cards.

Visible symptom: the product-card "See More" (add-to-cart) button sat at its intrinsic ~132px auto-width instead of filling the card, and the `.woo-listing-top` result/sort bar lost its borders.

## Change
Broadened the gate to `is_shop() || is_product_taxonomy() || is_front_page()`. `is_product_taxonomy()` is WooCommerce core's `is_tax( get_object_taxonomies('product') )`, a strict superset of `is_product_category() || is_product_tag()` that also covers `product_brand` and any `pa_*` attribute archive. No behavior change on shop / category / tag / homepage; the only new surface is custom product-taxonomy archives, which now get the same polish. Theme version 1.1.49 -> 1.1.50.

## Test plan
- On a `product_brand` archive (e.g. TNM `/brand/the-natural-mattress-home/`): the "See More" button fills the card width at 320/375/425/768/1024/1440/2560px and `.woo-listing-top` shows its borders, matching `/shop/`.
- Regression: `/shop/`, a product category archive, a product tag archive, and the homepage all render identically to before (same assets, same load order).
- Cross-client QA: this now also loads `woo-archive.css` on `pa_*` attribute archives for every site on this base theme. Confirm those archives still look right where they are used before merging.

## Related
- Surfaced by: ClickUp https://app.clickup.com/t/86ey91293 (TNM Retheme - Brand Archive)
- Site-level overlay that unblocks the TNM task now: bc-site-customizations #327 (scoped to `is_tax('product_brand')` under the same base handles; becomes a no-op once this lands).

## Session Resume
```bash
cd /Users/alanregaya/Documents/.work/.blz/.worktrees/blaze-blocksy-86ey91293 && claude --resume 0de80264-54bc-46ac-ad5c-0d3fe9f90b46 --allow-dangerously-skip-permissions --permission-mode plan
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
