### PR TITLE
feat(thenaturalmattress): search dropdown item count + See-all format (86ey72bye)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [tnm-search-item-count-2026-07-21] - 2026-07-21
+
+### Added
+- `assets/js/search-restructure.js`: QA round 2 (Vita) on the TNM search popup wanted the Figma item count. `addSectionCounts()` now appends the count to each section heading, e.g. "Categories (6)" / "Products (7)", read from the rendered results (the products heading uses the total when FiboSearch provides it). `buildViewAllLink()` reformats the See-all link to the Figma "SEE ALL PRODUCTS (N)" (was "SEE ALL N PRODUCTS"). Because FiboSearch only emits its `more_products` total on a full catalogue (prod, like HNM) and its TNTSearch AJAX endpoint runs under WordPress SHORTINIT (no theme filter can force it), the count falls back to the number of products shown when no total is sent, so the small staging catalogue (11 products) still shows an accurate count. Deployed to tnmretheme.kinsta.cloud; verified at 320/375/425/768/1024/1440/2560px. ClickUp 86ey72bye.
+
 ## [wishlist-drawer-category-labels-2026-06-30] - 2026-06-30
 
 ### Fixed

--- a/assets/js/search-restructure.js
+++ b/assets/js/search-restructure.js
@@ -35,7 +35,9 @@
 
 	function buildViewAllLink(query, total) {
 		const q = query || getActiveQuery();
-		const label = total ? `SEE ALL ${total} PRODUCTS` : 'SEE ALL PRODUCTS';
+		// QA round 2 (Vita, 86ey72bye): match the Figma "SEE ALL PRODUCTS (N)" format,
+		// where N is the total matching products (from FiboSearch's more_products link).
+		const label = total ? `SEE ALL PRODUCTS (${total})` : 'SEE ALL PRODUCTS';
 		const a = el('a', {
 			href: `/?s=${encodeURIComponent(q)}&post_type=product`,
 			class: 'dgwt-wcas-view-all',
@@ -95,6 +97,27 @@
 		wrapper.appendChild(content);
 
 		return { wrapper, content };
+	}
+
+	/**
+	 * Append the item count to each section heading, e.g. "Products (5)".
+	 * QA round 2 (Vita, 86ey72bye): the Figma shows a per-section count next to the
+	 * heading. For the products section the Figma count equals the See-all figure
+	 * (the total matching products), so use productsTotal there when it is known;
+	 * for the other sections use the number of results rendered. Idempotent: strips
+	 * any existing "(n)" before appending so a re-run does not stack counts.
+	 */
+	function addSectionCounts(container, productsTotal) {
+		container.querySelectorAll('.dgwt-wcas-suggestion-section').forEach(function (section) {
+			const title = section.querySelector('.dgwt-wcas-section-title');
+			const content = section.querySelector('.dgwt-wcas-section-content');
+			if (!title || !content) return;
+			const isProducts = section.classList.contains('dgwt-wcas-section-products');
+			let count = content.children.length;
+			if (isProducts && productsTotal) count = productsTotal;
+			if (!count) return;
+			title.textContent = title.textContent.replace(/\s*\(\d+\)\s*$/, '') + ' (' + count + ')';
+		});
 	}
 
 	function process(container) {
@@ -176,6 +199,14 @@
 			// Add "SEE ALL" link to products section
 			const productsSection = fragment.querySelector('.dgwt-wcas-section-products');
 			if (productsSection) {
+				if (!viewAllTotal) {
+					// No more_products total from FiboSearch: on a full catalogue it
+					// sends one because the results shown are fewer than the total, but
+					// when every matching product already fits (small catalogue) the
+					// shown count IS the total, so use it. (86ey72bye)
+					const shown = productsSection.querySelectorAll('.dgwt-wcas-section-content > *').length;
+					if (shown) viewAllTotal = String(shown);
+				}
 				productsSection.appendChild(buildViewAllLink(query, viewAllTotal));
 			}
 
@@ -188,6 +219,7 @@
 
 			container.innerHTML = '';
 			container.appendChild(ordered);
+			addSectionCounts(container, viewAllTotal);
 			addSearchHeader(container);
 			upgradeImages(container);
 			disableFiboHover(container);
@@ -327,10 +359,16 @@
 			}
 		}
 
+		if (!viewAllTotal) {
+			// Small catalogue: no more_products total, so the shown count is the total. (86ey72bye)
+			const shown = section.content.children.length;
+			if (shown) viewAllTotal = String(shown);
+		}
 		section.wrapper.appendChild(buildViewAllLink(query, viewAllTotal));
 
 		container.innerHTML = '';
 		container.appendChild(section.wrapper);
+		addSectionCounts(container, viewAllTotal);
 		addSearchHeader(container);
 		upgradeImages(container);
 		disableFiboHover(container);


### PR DESCRIPTION
## Summary

TNM search popup, QA round 2 (Vita), task [86ey72bye](https://app.clickup.com/t/86ey72bye): "the search should contain how many items, please refer to figma design".

`assets/js/search-restructure.js` (TNM-specific dropdown rewriter):
- `addSectionCounts()`: appends the item count to each section heading, e.g. "Categories (6)" / "Products (7)". The products heading uses FiboSearch's total when available, other sections use the rendered count.
- `buildViewAllLink()`: reformats the See-all link to the Figma "SEE ALL PRODUCTS (N)" (was "SEE ALL N PRODUCTS").
- Count fallback: FiboSearch only emits its `more_products` total when the results shown are fewer than the total, and its TNTSearch AJAX endpoint runs under WordPress `SHORTINIT` (no theme/plugin/mu-plugin loads, so no theme filter can force it). On a full catalogue (prod, like HNM) the total is present; on the small staging catalogue (11 products) every match already fits, so the count falls back to the number of products shown, which is the true total there.

Companion PR (bc-site-customizations #457) enables `show_product_price` and fixes the mobile overlay fill.

## Test plan

- Deployed to `tnmretheme.kinsta.cloud` via scp (server is the source of truth for this repo) + Perfmatters/Kinsta purge.
- Verified at 320/375/425/768/1024/1440/2560px: desktop and mobile overlay both show "Products (7)" and "SEE ALL PRODUCTS (7)". Idempotent (re-run does not stack counts); `node --check` clean.
- Before/after screenshot proof at all 7 breakpoints posted to the ClickUp task.

## Session Resume

```
cd /Users/alanregaya/Documents/.work/.blz/.worktrees/blaze-blocksy-86ey72bye-searchcount && claude --resume 8b7007ff-9a7c-4597-bd00-56d566e6fc4b --allow-dangerously-skip-permissions --permission-mode plan
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
