### PR TITLE
fix(header): cover the 1000-1080px off-canvas dead band (86eyeevb8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [offcanvas-band-panel-width-2026-07-28] - 2026-07-28
+
+### Changed
+- `assets/css/components/header.css`: theme 1.1.50 to 1.1.51. Cap the off-canvas panel width in the 1000 to 1080px band at `min(65vw, 650px)`. Restating Blocksy's raw tablet `65vw` inside that block fixed the colours but let the panel keep growing with the viewport, reaching 702px at 1080px, so the menu occupied two thirds of a desktop-sized screen with its labels stranded in a wide empty panel. The cap holds the panel at the 650px it already had at 999px, which keeps the 999 to 1000 handoff seamless and stops it widening into desktop territory. ClickUp 86eyeevb8.
+
 ## [offcanvas-breakpoint-band-2026-07-28] - 2026-07-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [offcanvas-breakpoint-band-2026-07-28] - 2026-07-28
+
+### Fixed
+- `assets/css/components/header.css`: theme 1.1.49 to 1.1.50. The header had a dead band at 1000 to 1080px where the off-canvas menu rendered unreadable and the page behind it looked blank. The iPad Pro device swap in that block hands the header to the mobile variant up to 1080px, but Blocksy scopes its `#offcanvas` panel styling to `@media (max-width: 999.98px)` (its tablet device breakpoint) in the compiled `global.css`. So 1000 to 1080 ran the hamburger menu with Blocksy's desktop panel defaults: panel background `rgba(18,21,25,.98)` under `#343437` label text (near zero contrast), and no overlay colour on `#offcanvas` itself, which falls back to opaque white and paints over the page behind the menu. The panel also narrowed from 65vw to 390px. The block now restates Blocksy's tablet panel values so the band is covered, using `var(--theme-palette-color-7)` for the panel so each site keeps its own colour. Measured on aworld-retheme.blz.au at fixed widths (not a drag frame): broken at 1000/1024/1080, correct at 999 and from 1081 up. Byron Bay and any other site on this theme get the same coverage. ClickUp 86eyeevb8.
+
 ## [tnm-search-item-count-2026-07-21] - 2026-07-21
 
 ### Added

--- a/assets/css/components/header.css
+++ b/assets/css/components/header.css
@@ -253,15 +253,24 @@
 	   Breakpoint handoff, so the boundary is unambiguous:
 	     up to 689.98px   Blocksy mobile device, panel styled by global.css
 	     up to 999.98px   Blocksy tablet device, panel styled by global.css
-	     1000 to 1080px   mobile header, desktop panel values (this block)
+	     1000 to 1080px   mobile header, panel styled by this block
 	     1081px and up    desktop header, off-canvas not in use
 
 	   Values mirror Blocksy's tablet block. --theme-palette-color-7 is each
 	   site's own panel colour, so this stays correct per site.
+
+	   Width is capped rather than left at a bare 65vw. Blocksy's tablet
+	   setting is 65vw, which reaches 649px at the top of the tablet range
+	   (999.98px). Carrying the raw percentage into this band would keep
+	   growing it to 702px at 1080px, so the menu takes two thirds of a
+	   desktop-sized viewport and leaves the labels stranded in a wide empty
+	   panel. min() holds it at the width it already had at 999px, which
+	   keeps the 999 to 1000 handoff seamless and stops the panel widening
+	   into desktop territory where the design never asked for it.
 	   @date 2026-07-28 (CU-86eyeevb8) */
 	[data-header*="type-1"] #offcanvas {
 		background-color: rgba(18, 21, 25, 0.5);
-		--side-panel-width: 65vw;
+		--side-panel-width: min(65vw, 650px);
 		--horizontal-alignment: initial;
 		--text-horizontal-alignment: initial;
 	}

--- a/assets/css/components/header.css
+++ b/assets/css/components/header.css
@@ -239,6 +239,37 @@
 		display: block !important;
 	}
 
+	/* Off-canvas menu panel: restate the tablet values inside this band.
+	   WHY: Blocksy scopes the #offcanvas panel styling to its own tablet
+	   device breakpoint, `@media (max-width: 999.98px)` in the compiled
+	   global.css. The device swap above hands the header to the mobile
+	   variant all the way to 1080px, so 1000 to 1080 ran the hamburger menu
+	   with Blocksy's DESKTOP panel defaults: a dark panel
+	   (rgba(18,21,25,.98)) under dark label text, and no overlay colour on
+	   #offcanvas itself, which falls back to opaque white and paints over
+	   the page behind the menu. Same class of mismatch as the
+	   --logo-max-height override above.
+
+	   Breakpoint handoff, so the boundary is unambiguous:
+	     up to 689.98px   Blocksy mobile device, panel styled by global.css
+	     up to 999.98px   Blocksy tablet device, panel styled by global.css
+	     1000 to 1080px   mobile header, desktop panel values (this block)
+	     1081px and up    desktop header, off-canvas not in use
+
+	   Values mirror Blocksy's tablet block. --theme-palette-color-7 is each
+	   site's own panel colour, so this stays correct per site.
+	   @date 2026-07-28 (CU-86eyeevb8) */
+	[data-header*="type-1"] #offcanvas {
+		background-color: rgba(18, 21, 25, 0.5);
+		--side-panel-width: 65vw;
+		--horizontal-alignment: initial;
+		--text-horizontal-alignment: initial;
+	}
+
+	[data-header*="type-1"] #offcanvas .ct-panel-inner {
+		background-color: var(--theme-palette-color-7);
+	}
+
 	/* Reduce container padding for tablet spacing */
 	#header .ct-container {
 		padding-left: 15px !important;

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:       Blaze Commerce
  Author URI:   https://blazecommerce.io/
  Template:     blocksy
- Version:      1.1.49
+ Version:      1.1.50
  Text Domain:  blocksy-child
  License:      GNU General Public License v2 or later
  License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:       Blaze Commerce
  Author URI:   https://blazecommerce.io/
  Template:     blocksy
- Version:      1.1.50
+ Version:      1.1.51
  Text Domain:  blocksy-child
  License:      GNU General Public License v2 or later
  License URI:  https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary

Covers a dead band in the header at **1000 to 1080px** where the off-canvas menu rendered unreadable and the page behind it looked blank.

ClickUp: https://app.clickup.com/t/86eyeevb8

## Root cause

Two breakpoints disagreed:

1. `assets/css/components/header.css:229` swaps the desktop header for the mobile one across `@media (min-width: 1000px) and (max-width: 1080px)` (the iPad Pro fix, 2026-04-16).
2. Blocksy styles `#offcanvas` only inside `@media (max-width: 999.98px)` in the compiled `global.css`, its tablet device breakpoint.

So 1000 to 1080px ran the hamburger menu with Blocksy's **desktop** panel defaults.

Measured on `aworld-retheme.blz.au` at fixed widths, not a drag frame:

| Width | `#offcanvas` background | `.ct-panel-inner` background | Panel width | Hamburger |
|---|---|---|---|---|
| 999px | `rgba(18,21,25,.5)` scrim | `#FFFFFF` | 649px | visible |
| 1000 to 1080px | **`#FFFFFF` opaque** | **`rgba(18,21,25,.98)`** | 390px | visible |
| 1081px and up | n/a | n/a | n/a | hidden, desktop header |

One cause explains all three reported symptoms. Labels are `#343437`, so on the dark panel the contrast is near zero. `#offcanvas` itself had no overlay colour, fell back to opaque white and painted over the page, which is the "blank page" report. The panel also narrowed from 65vw to 390px.

The page content was never actually missing: `main` measured 1080x5798, `display: block`, `visibility: visible`.

## Fix

Restates Blocksy's tablet panel values inside the existing band block, and documents the full breakpoint handoff in a comment so the boundary is unambiguous.

`var(--theme-palette-color-7)` is each site's own panel colour, so this stays correct per site rather than hardcoding Alternate Worlds' palette.

Panel width is `min(65vw, 650px)` rather than a bare `65vw`. Blocksy's tablet setting reaches 649px at the top of the tablet range; carried raw into this band it kept growing to 702px at 1080px, so the menu took two thirds of a desktop-sized viewport with its labels stranded in a wide empty panel. The cap holds it at the width it already had at 999px, which keeps the 999 to 1000 handoff seamless.

## Test plan

- [x] Cascade check passed at 1000/1024/1080px against the tablet reference values
- [x] Before and after captures at 320/375/425/768/1024/1440/2560 plus band edges 1000/1080/1081
- [x] Deployed and verified on V1 `aworld-retheme.blz.au` and GLS `aworldglsv1.kinsta.cloud`
- [ ] QA sign off

### Evidence

Cascade check first. The new rules were inserted into the real `header.css` stylesheet object at its actual position in the cascade (index 24 against `global.css` at index 1), rather than appending a `<style>` tag that would win on source order and prove nothing. PASS at 1000, 1024 and 1080px.

Live sweep on both environments, plain page loads after a Kinsta cache purge, so this is what a visitor receives:

```
 320px hamburger=Y panel=rgba(0, 0, 0, 0.5)     inner=rgba(255,255,255,.98) w=291 PASS contrast=12.41:1
 999px hamburger=Y panel=rgba(18, 21, 25, 0.5)  inner=rgb(255, 255, 255)    w=649 PASS contrast=12.41:1
1000px hamburger=Y panel=rgba(18, 21, 25, 0.5)  inner=rgb(255, 255, 255)    w=650 PASS contrast=12.41:1
1024px hamburger=Y panel=rgba(18, 21, 25, 0.5)  inner=rgb(255, 255, 255)    w=650 PASS contrast=12.41:1
1080px hamburger=Y panel=rgba(18, 21, 25, 0.5)  inner=rgb(255, 255, 255)    w=650 PASS contrast=12.41:1
1081px hamburger=n  desktop header, off-canvas not in use
2560px hamburger=n  desktop header, off-canvas not in use

RESULT v1:  no dead band across 320 to 2560px
RESULT gls: no dead band across 320 to 2560px
```

Every width named in the ticket's acceptance criteria (999, 1000, 1024, 1080, 1200, 1218, 1280, 1440) was measured explicitly on both environments. Before and after composites are in a thread reply on the ClickUp task.

## Note on `style.css`

The version bump to 1.1.51 lives in the theme's root `style.css`, which the child-theme write gate blocks from being pushed to a server, so both servers still report 1.1.50. No runtime effect here, since cache-busting comes from each file's own modified time, but repo and servers will only agree once this merges and syncs.

## Session Resume
```bash
cd /Users/alanregaya/Documents/.work/.blz && claude --resume 54318d3e-5660-476e-b6a3-30e5b057297c --allow-dangerously-skip-permissions --permission-mode plan
```

## Blast radius

This is the shared child theme, so every site on it gets the same coverage. The rules only exist inside the 1000 to 1080px band, which is already mobile-header territory for all of them, and the panel colour comes from each site's own palette variable. Nothing outside that band changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
